### PR TITLE
Bug fix organisationSearch.ejs

### DIFF
--- a/src/app/services/views/organisationsSearch.ejs
+++ b/src/app/services/views/organisationsSearch.ejs
@@ -70,7 +70,7 @@ const paginationModel = {
                     <td><%= organisations[i].urn %></td>
                     <td><%= organisations[i].uid %></td>
                     <td><%= organisations[i].ukprn %></td>
-                    <td><%= organisations[i].status.name %></td>
+                    <td><%= organisations[i].status!==undefined ? organisations[i].status.name : '' %></td>
                 </tr>
             <% } %>
             </tbody>


### PR DESCRIPTION
Bug that prevents organisationSearch.ejs being rendered if organisation status is undefined within the DB