### PR TITLE
[NSA-7073] clientId validation

### DIFF
--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -98,7 +98,7 @@ const validate = async (req) => {
     model.validationMessages.clientId = 'Client Id must only contain letters, numbers, and hyphens';
   } else if (model.service.clientId !== service.relyingParty.client_id && getServiceById(model.service.clientId, req.id)) {
     // If getServiceById returns truthy, then that clientId is already in use.
-    model.validationMessages.clientId = 'Client Id is unavailable, please try another';
+    model.validationMessages.clientId = 'Client Id is unavailable, try another';
   }
 
   if (!urlValidation.test(model.service.postResetUrl) && model.service.postResetUrl.trim() !== '') {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -94,6 +94,8 @@ const validate = async (req) => {
     model.validationMessages.clientId = 'Client Id must be present';
   } else if (model.service.clientId.length > 50) {
     model.validationMessages.clientId = 'Client Id must be 50 characters or less';
+  } else if (!/^[A-Za-z0-9-]+$/.test(model.service.clientId)) {
+    model.validationMessages.clientId = 'Client Id must only contain letters, numbers, and hyphens';
   }
 
   if (!urlValidation.test(model.service.postResetUrl) && model.service.postResetUrl.trim() !== '') {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -92,6 +92,8 @@ const validate = async (req) => {
 
   if (!model.service.clientId) {
     model.validationMessages.clientId = 'Client Id must be present';
+  } else if (model.service.clientId.length > 50) {
+    model.validationMessages.clientId = 'Client Id must be 50 characters or less';
   }
 
   if (!urlValidation.test(model.service.postResetUrl) && model.service.postResetUrl.trim() !== '') {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -96,6 +96,9 @@ const validate = async (req) => {
     model.validationMessages.clientId = 'Client Id must be 50 characters or less';
   } else if (!/^[A-Za-z0-9-]+$/.test(model.service.clientId)) {
     model.validationMessages.clientId = 'Client Id must only contain letters, numbers, and hyphens';
+  } else if (model.service.clientId !== service.relyingParty.client_id && getServiceById(model.service.clientId, req.id)) {
+    // If getServiceById returns truthy, then that clientId is already in use.
+    model.validationMessages.clientId = 'Client Id is unavailable, please try another';
   }
 
   if (!urlValidation.test(model.service.postResetUrl) && model.service.postResetUrl.trim() !== '') {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -96,7 +96,7 @@ const validate = async (req) => {
     model.validationMessages.clientId = 'Client Id must be 50 characters or less';
   } else if (!/^[A-Za-z0-9-]+$/.test(model.service.clientId)) {
     model.validationMessages.clientId = 'Client Id must only contain letters, numbers, and hyphens';
-  } else if (model.service.clientId !== service.relyingParty.client_id && getServiceById(model.service.clientId, req.id)) {
+  } else if (model.service.clientId !== service.relyingParty.client_id && await getServiceById(model.service.clientId, req.id)) {
     // If getServiceById returns truthy, then that clientId is already in use.
     model.validationMessages.clientId = 'Client Id is unavailable, try another';
   }

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -150,7 +150,7 @@
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 <label for="clientId" class="govuk-label govuk-label--s">
-                                    Client Id (Up to 50 alphanumeric characters and hyphens)
+                                    Client Id (Up to 50 characters including letters, numbers, and hyphens)
                                 </label>
                             </dt>
                             <dd class="govuk-summary-list__value">

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -150,7 +150,7 @@
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 <label for="clientId" class="govuk-label govuk-label--s">
-                                    Client Id
+                                    Client Id (Up to 50 alphanumeric characters and hyphens)
                                 </label>
                             </dt>
                             <dd class="govuk-summary-list__value">

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -226,6 +226,80 @@ describe('when editing the service configuration', () => {
     });
   });
 
+  it('then it should render view with validation if clientId is not alphanumeric & hyphens', async () => {
+    const testClientId = 't89-^&*2tIu-';
+    req.body.clientId = testClientId;
+
+    await postServiceConfig(req, res);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/serviceConfig');
+    expect(res.render.mock.calls[0][1]).toEqual({
+      backLink: '/services/service1',
+      csrfToken: 'token',
+      currentNavigation: 'configuration',
+      service: {
+        name: 'service two',
+        clientId: testClientId,
+        clientSecret: 'outshine-wringing-imparting-submitted',
+        description: 'service description',
+        grantTypes: [
+          'implicit',
+        ],
+        postLogoutRedirectUris: [
+          'https://www.logout2.com',
+        ],
+        postResetUrl: 'https://www.postreset2.com',
+        redirectUris: [
+          'https://www.redirect.com',
+          'https://www.redirect2.com',
+        ],
+        responseTypes: [
+          'code',
+        ],
+        serviceHome: 'https://www.servicehome2.com',
+      },
+      serviceId: 'service1',
+      userRoles: [],
+      validationMessages: {
+        clientId: 'Client Id must only contain letters, numbers, and hyphens',
+      },
+    });
+  });
+
+  it('then it should update the service if clientId is alphanumeric & hyphens', async () => {
+    const testClientId = 't89B-2tVuX-';
+    req.body.clientId = testClientId;
+
+    await postServiceConfig(req, res);
+
+    expect(updateService.mock.calls).toHaveLength(1);
+    expect(updateService.mock.calls[0][0]).toBe('service1');
+
+    expect(updateService.mock.calls[0][1]).toEqual({
+      name: 'service two',
+      description: 'service description',
+      clientId: testClientId,
+      clientSecret: 'outshine-wringing-imparting-submitted',
+      serviceHome: 'https://www.servicehome2.com',
+      postResetUrl: 'https://www.postreset2.com',
+      tokenEndpointAuthMethod: null,
+      redirect_uris: [
+        'https://www.redirect.com',
+        'https://www.redirect2.com',
+      ],
+      post_logout_redirect_uris: [
+        'https://www.logout2.com',
+      ],
+      grant_types: [
+        'implicit',
+      ],
+      response_types: [
+        'code',
+      ],
+    });
+    expect(updateService.mock.calls[0][2]).toBe('correlationId');
+  });
+
   it('then it should render view with validation if redirect urls are not unique', async () => {
     req.body.redirect_uris =  [
       'https://www.redirect.com',

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -42,9 +42,9 @@ describe('when editing the service configuration', () => {
 
     updateService.mockReset();
     getServiceById.mockReset();
-    getServiceById.mockReturnValue({
+    getServiceById.mockReturnValueOnce({
       id: 'service1',
-      name:'service one',
+      name: 'service one',
       description: 'service description',
       relyingParty: {
         client_id: 'clientid',
@@ -65,8 +65,8 @@ describe('when editing the service configuration', () => {
         response_types: [
           'code',
         ],
-      }
-    });
+      },
+    }).mockReturnValueOnce(null);
     res.mockResetAll();
   });
 
@@ -279,6 +279,111 @@ describe('when editing the service configuration', () => {
       name: 'service two',
       description: 'service description',
       clientId: testClientId,
+      clientSecret: 'outshine-wringing-imparting-submitted',
+      serviceHome: 'https://www.servicehome2.com',
+      postResetUrl: 'https://www.postreset2.com',
+      tokenEndpointAuthMethod: null,
+      redirect_uris: [
+        'https://www.redirect.com',
+        'https://www.redirect2.com',
+      ],
+      post_logout_redirect_uris: [
+        'https://www.logout2.com',
+      ],
+      grant_types: [
+        'implicit',
+      ],
+      response_types: [
+        'code',
+      ],
+    });
+    expect(updateService.mock.calls[0][2]).toBe('correlationId');
+  });
+
+  it('then it should render view with validation if clientId is already in use by another service', async () => {
+    const testClientId = 'existing-id';
+    req.body.clientId = testClientId;
+
+    // Change mock to return truthy on second call to mimic a service existing with the clientId.
+    getServiceById.mockReset();
+    getServiceById.mockReturnValueOnce({
+      id: 'service1',
+      name: 'service one',
+      description: 'service description',
+      relyingParty: {
+        client_id: 'clientid',
+        client_secret: 'dewier-thrombi-confounder-mikado',
+        api_secret: 'dewier-thrombi-confounder-mikado',
+        service_home: 'https://www.servicehome.com',
+        postResetUrl: 'https://www.postreset.com',
+        redirect_uris: [
+          'https://www.redirect.com',
+        ],
+        post_logout_redirect_uris: [
+          'https://www.logout.com',
+        ],
+        grant_types: [
+          'implicit',
+          'authorization_code',
+        ],
+        response_types: [
+          'code',
+        ],
+      },
+    }).mockReturnValueOnce({
+      example: true,
+    });
+
+    await postServiceConfig(req, res);
+    // getServiceById should be called twice to get service info and check clientId uniqueness.
+    expect(getServiceById.mock.calls).toHaveLength(2);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/serviceConfig');
+    expect(res.render.mock.calls[0][1]).toEqual({
+      backLink: '/services/service1',
+      csrfToken: 'token',
+      currentNavigation: 'configuration',
+      service: {
+        name: 'service two',
+        clientId: testClientId,
+        clientSecret: 'outshine-wringing-imparting-submitted',
+        description: 'service description',
+        grantTypes: [
+          'implicit',
+        ],
+        postLogoutRedirectUris: [
+          'https://www.logout2.com',
+        ],
+        postResetUrl: 'https://www.postreset2.com',
+        redirectUris: [
+          'https://www.redirect.com',
+          'https://www.redirect2.com',
+        ],
+        responseTypes: [
+          'code',
+        ],
+        serviceHome: 'https://www.servicehome2.com',
+      },
+      serviceId: 'service1',
+      userRoles: [],
+      validationMessages: {
+        clientId: 'Client Id is unavailable, please try another',
+      },
+    });
+  });
+
+  it('then it should still update the service if the clientId has not been edited', async () => {
+    req.body.clientId = 'clientid';
+
+    await postServiceConfig(req, res);
+    // getServiceById should only be called once as the uniqueness check won't be used.
+    expect(getServiceById.mock.calls).toHaveLength(1);
+    expect(updateService.mock.calls).toHaveLength(1);
+    expect(updateService.mock.calls[0][0]).toBe('service1');
+    expect(updateService.mock.calls[0][1]).toEqual({
+      name: 'service two',
+      description: 'service description',
+      clientId: 'clientid',
       clientSecret: 'outshine-wringing-imparting-submitted',
       serviceHome: 'https://www.servicehome2.com',
       postResetUrl: 'https://www.postreset2.com',

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -367,7 +367,7 @@ describe('when editing the service configuration', () => {
       serviceId: 'service1',
       userRoles: [],
       validationMessages: {
-        clientId: 'Client Id is unavailable, please try another',
+        clientId: 'Client Id is unavailable, try another',
       },
     });
   });

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -186,6 +186,46 @@ describe('when editing the service configuration', () => {
     });
   });
 
+  it('then it should render view with validation if clientId is longer than 50 characters', async () => {
+    const testClientId = 'a'.repeat(100);
+    req.body.clientId = testClientId;
+
+    await postServiceConfig(req, res);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/serviceConfig');
+    expect(res.render.mock.calls[0][1]).toEqual({
+      backLink: '/services/service1',
+      csrfToken: 'token',
+      currentNavigation: 'configuration',
+      service: {
+        name: 'service two',
+        clientId: testClientId,
+        clientSecret: 'outshine-wringing-imparting-submitted',
+        description: 'service description',
+        grantTypes: [
+          'implicit',
+        ],
+        postLogoutRedirectUris: [
+          'https://www.logout2.com',
+        ],
+        postResetUrl: 'https://www.postreset2.com',
+        redirectUris: [
+          'https://www.redirect.com',
+          'https://www.redirect2.com',
+        ],
+        responseTypes: [
+          'code',
+        ],
+        serviceHome: 'https://www.servicehome2.com',
+      },
+      serviceId: 'service1',
+      userRoles: [],
+      validationMessages: {
+        clientId: 'Client Id must be 50 characters or less',
+      },
+    });
+  });
+
   it('then it should render view with validation if redirect urls are not unique', async () => {
     req.body.redirect_uris =  [
       'https://www.redirect.com',


### PR DESCRIPTION
Implementation for: https://dfe-secureaccess.atlassian.net/browse/NSA-7073

- Added text to client ID label stating it must be up to 50 characters including letters, numbers, and hyphens.
- Added validation to ensure the client ID is 50 characters or less (DB column size), fits a regex of alphanumeric characters and hyphens, and checks whether the client ID is in use already.
- Added testing for the new validation, the beforeEach has been changed for the postServiceConfig test suite to account for the client ID in use check.

Before this change, if a client ID was too long or already in use a 'An error has occurred page' would have been displayed, and there was no validation on the characters used in the client ID.