### PR TITLE
[NSA-7073] Move clientId validation guide to govuk-hint

### DIFF
--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -150,7 +150,8 @@
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 <label for="clientId" class="govuk-label govuk-label--s">
-                                    Client Id (Up to 50 characters including letters, numbers, and hyphens)
+                                    Client Id
+                                    <span class="govuk-hint">(Up to 50 characters including letters, numbers, and hyphens)</span>
                                 </label>
                             </dt>
                             <dd class="govuk-summary-list__value">


### PR DESCRIPTION
A UI improvement for NSA-7073, moving the validation information for length and character set into a `govuk-hint` span, to improve readability and wrapping.