### PR TITLE
[NSA-7161 & NSA-7154] Minor validation bugs

### DIFF
--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -96,7 +96,10 @@ const validate = async (req) => {
     model.validationMessages.clientId = 'Client Id must be 50 characters or less';
   } else if (!/^[A-Za-z0-9-]+$/.test(model.service.clientId)) {
     model.validationMessages.clientId = 'Client Id must only contain letters, numbers, and hyphens';
-  } else if (model.service.clientId !== service.relyingParty.client_id && await getServiceById(model.service.clientId, req.id)) {
+  } else if (
+    model.service.clientId.toLowerCase() !== service.relyingParty.client_id.toLowerCase()
+    && await getServiceById(model.service.clientId, req.id)
+  ) {
     // If getServiceById returns truthy, then that clientId is already in use.
     model.validationMessages.clientId = 'Client Id is unavailable, try another';
   }

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -73,7 +73,7 @@ const validate = async (req) => {
       grantTypes,
       responseTypes,
       apiSecret: req.body.apiSecret,
-      tokenEndpointAuthMethod: req.body.tokenEndpointAuthMethod,
+      tokenEndpointAuthMethod: req.body.tokenEndpointAuthMethod === 'client_secret_post' ? 'client_secret_post' : null,
     },
     backLink: `/services/${req.params.sid}`,
     validationMessages: {},

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -447,6 +447,91 @@ describe('when editing the service configuration', () => {
     });
   });
 
+  it('then validation should set the token auth method to "client_secret_post" if that is what it was set to when there is a validation error', async () => {
+    req.body.tokenEndpointAuthMethod = 'client_secret_post';
+    const testClientId = 't89-^&*2tIu-';
+    req.body.clientId = testClientId;
+
+    await postServiceConfig(req, res);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/serviceConfig');
+    expect(res.render.mock.calls[0][1]).toEqual({
+      backLink: '/services/service1',
+      csrfToken: 'token',
+      currentNavigation: 'configuration',
+      service: {
+        name: 'service two',
+        clientId: testClientId,
+        clientSecret: 'outshine-wringing-imparting-submitted',
+        description: 'service description',
+        grantTypes: [
+          'implicit',
+        ],
+        postLogoutRedirectUris: [
+          'https://www.logout2.com',
+        ],
+        postResetUrl: 'https://www.postreset2.com',
+        redirectUris: [
+          'https://www.redirect.com',
+          'https://www.redirect2.com',
+        ],
+        responseTypes: [
+          'code',
+        ],
+        serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: 'client_secret_post',
+      },
+      serviceId: 'service1',
+      userRoles: [],
+      validationMessages: {
+        clientId: 'Client Id must only contain letters, numbers, and hyphens',
+      },
+    });
+  });
+
+  it('then validation should set the token auth method to null if it was set to "none" when there is a validation error', async () => {
+    // none is the value on the form input, which should be translated to null.
+    req.body.tokenEndpointAuthMethod = 'none';
+    const testClientId = 't89-^&*2tIu-';
+    req.body.clientId = testClientId;
+
+    await postServiceConfig(req, res);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/serviceConfig');
+    expect(res.render.mock.calls[0][1]).toEqual({
+      backLink: '/services/service1',
+      csrfToken: 'token',
+      currentNavigation: 'configuration',
+      service: {
+        name: 'service two',
+        clientId: testClientId,
+        clientSecret: 'outshine-wringing-imparting-submitted',
+        description: 'service description',
+        grantTypes: [
+          'implicit',
+        ],
+        postLogoutRedirectUris: [
+          'https://www.logout2.com',
+        ],
+        postResetUrl: 'https://www.postreset2.com',
+        redirectUris: [
+          'https://www.redirect.com',
+          'https://www.redirect2.com',
+        ],
+        responseTypes: [
+          'code',
+        ],
+        serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
+      },
+      serviceId: 'service1',
+      userRoles: [],
+      validationMessages: {
+        clientId: 'Client Id must only contain letters, numbers, and hyphens',
+      },
+    });
+  });
+
   it('then it should update the service', async () => {
     await postServiceConfig(req, res);
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -378,6 +378,39 @@ describe('when editing the service configuration', () => {
     });
   });
 
+  it('then it should still update the service if only the clientId capitalisation has changed', async () => {
+    req.body.clientId = 'cLiEnTiD';
+
+    await postServiceConfig(req, res);
+    // getServiceById should only be called once as the uniqueness check won't be used.
+    expect(getServiceById.mock.calls).toHaveLength(1);
+    expect(updateService.mock.calls).toHaveLength(1);
+    expect(updateService.mock.calls[0][0]).toBe('service1');
+    expect(updateService.mock.calls[0][1]).toEqual({
+      name: 'service two',
+      description: 'service description',
+      clientId: 'cLiEnTiD',
+      clientSecret: 'outshine-wringing-imparting-submitted',
+      serviceHome: 'https://www.servicehome2.com',
+      postResetUrl: 'https://www.postreset2.com',
+      tokenEndpointAuthMethod: null,
+      redirect_uris: [
+        'https://www.redirect.com',
+        'https://www.redirect2.com',
+      ],
+      post_logout_redirect_uris: [
+        'https://www.logout2.com',
+      ],
+      grant_types: [
+        'implicit',
+      ],
+      response_types: [
+        'code',
+      ],
+    });
+    expect(updateService.mock.calls[0][2]).toBe('correlationId');
+  });
+
   it('then it should still update the service if the clientId has not been edited', async () => {
     req.body.clientId = 'clientid';
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -99,6 +99,7 @@ describe('when editing the service configuration', () => {
           'code'
         ],
         serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -137,7 +138,8 @@ describe('when editing the service configuration', () => {
         responseTypes: [
           'code'
         ],
-        serviceHome: 'not-a-url'
+        serviceHome: 'not-a-url',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -176,7 +178,8 @@ describe('when editing the service configuration', () => {
         responseTypes: [
           'code'
         ],
-        serviceHome: 'https://www.servicehome2.com'
+        serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -217,6 +220,7 @@ describe('when editing the service configuration', () => {
           'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -257,6 +261,7 @@ describe('when editing the service configuration', () => {
           'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -363,6 +368,7 @@ describe('when editing the service configuration', () => {
           'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -437,7 +443,8 @@ describe('when editing the service configuration', () => {
         responseTypes: [
           'code'
         ],
-        serviceHome: 'https://www.servicehome2.com'
+        serviceHome: 'https://www.servicehome2.com',
+        tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
       userRoles: [],


### PR DESCRIPTION
Implementation and testing for:

- https://dfe-secureaccess.atlassian.net/browse/NSA-7161
- https://dfe-secureaccess.atlassian.net/browse/NSA-7154

Addresses:

- Token endpoint auth method reverting to client_secret_post if there was a validation error, caused by it not translating the "none" input value to null, like it would do in the update object.
- Client ID check is now case insensitive, so services can change their own Client ID's capitalisation without receiving a "this client ID is unavailable" validation error.