### PR TITLE
NSA-7172 Add onboarding tile and navigation

### DIFF
--- a/src/app/layouts/layout.ejs
+++ b/src/app/layouts/layout.ejs
@@ -136,6 +136,15 @@
                                 </a>
                             </li>
                             <% } %>
+
+                            <% if (locals.userRoles && locals.userRoles.includes('onboarding')) { %>
+                            <li class="govuk-header__navigation-item <%= locals.currentNavigation === 'onboarding' ? 'govuk-header__navigation-item--active' : '' %>">
+                                <a id="nav-service-onboarding" class="govuk-header__link" href="/services/<%= locals.serviceId %>/onboarding">
+                                    Service Onboarding
+                                </a>
+                            </li>
+                            <% } %>
+
                         <% } %>
 
                             <li class="govuk-header__navigation-item">

--- a/src/app/layouts/layout.ejs
+++ b/src/app/layouts/layout.ejs
@@ -137,9 +137,9 @@
                             </li>
                             <% } %>
 
-                            <% if (locals.userRoles && locals.userRoles.includes('onboarding')) { %>
+                            <% if (locals.userRoles && locals.userRoles.includes('onboardSvc')) { %>
                             <li class="govuk-header__navigation-item <%= locals.currentNavigation === 'onboarding' ? 'govuk-header__navigation-item--active' : '' %>">
-                                <a id="nav-service-onboarding" class="govuk-header__link" href="/services/<%= locals.serviceId %>/onboarding">
+                                <a id="nav-onboard-service" class="govuk-header__link" href="/onboarding/service">
                                     Service Onboarding
                                 </a>
                             </li>

--- a/src/app/layouts/layout.ejs
+++ b/src/app/layouts/layout.ejs
@@ -139,7 +139,7 @@
 
                             <% if (locals.userRoles && locals.userRoles.includes('onboardSvc')) { %>
                             <li class="govuk-header__navigation-item <%= locals.currentNavigation === 'onboarding' ? 'govuk-header__navigation-item--active' : '' %>">
-                                <a id="nav-onboard-service" class="govuk-header__link" href="/onboarding/service">
+                                <a id="nav-onboard-service" class="govuk-header__link" href="/onboarding/<%= locals.serviceId %>/service">
                                     Service Onboarding
                                 </a>
                             </li>

--- a/src/app/onboarding/index.js
+++ b/src/app/onboarding/index.js
@@ -5,7 +5,7 @@ const { asyncWrapper } = require('login.dfe.express-error-handling');
 const logger = require('../../infrastructure/logger');
 const { isLoggedIn, isManageUserForService, hasRole } = require('../../infrastructure/utils');
 
-const { getServiceStartPage } = require('./service/getStartPage');
+const getServiceStartPage = require('./service/getStartPage');
 
 const router = express.Router({ mergeParams: true });
 

--- a/src/app/onboarding/index.js
+++ b/src/app/onboarding/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const express = require('express');
+const { asyncWrapper } = require('login.dfe.express-error-handling');
+const logger = require('../../infrastructure/logger');
+const { isLoggedIn, hasRole } = require('../../infrastructure/utils');
+
+const { getServiceStartPage } = require('./service/getStartPage');
+
+const router = express.Router({ mergeParams: true });
+
+const onboarding = (csrf) => {
+  logger.info('Mounting onboarding routes');
+  router.use(isLoggedIn);
+
+  router.get('/service', csrf, hasRole('onboardSvc'), asyncWrapper(getServiceStartPage));
+
+  return router;
+};
+
+module.exports = onboarding;

--- a/src/app/onboarding/index.js
+++ b/src/app/onboarding/index.js
@@ -3,7 +3,7 @@
 const express = require('express');
 const { asyncWrapper } = require('login.dfe.express-error-handling');
 const logger = require('../../infrastructure/logger');
-const { isLoggedIn, hasRole } = require('../../infrastructure/utils');
+const { isLoggedIn, isManageUserForService, hasRole } = require('../../infrastructure/utils');
 
 const { getServiceStartPage } = require('./service/getStartPage');
 
@@ -13,7 +13,7 @@ const onboarding = (csrf) => {
   logger.info('Mounting onboarding routes');
   router.use(isLoggedIn);
 
-  router.get('/service', csrf, hasRole('onboardSvc'), asyncWrapper(getServiceStartPage));
+  router.get('/:sid/service', csrf, isManageUserForService, hasRole('onboardSvc'), asyncWrapper(getServiceStartPage));
 
   return router;
 };

--- a/src/app/onboarding/service/getStartPage.js
+++ b/src/app/onboarding/service/getStartPage.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { getUserServiceRoles } = require('../../../utils/getUserServiceRoles');
+
+const getStartPage = async (req, res) => {
+  const manageRolesForService = await getUserServiceRoles(req);
+
+  return res.render('onboarding/service/views/startPage', {
+    csrfToken: req.csrfToken(),
+    backLink: `/services/${req.params.sid}`,
+    serviceId: req.params.sid,
+    userRoles: manageRolesForService,
+    currentNavigation: 'onboarding',
+  });
+};
+
+module.exports = getStartPage;

--- a/src/app/onboarding/service/views/startPage.ejs
+++ b/src/app/onboarding/service/views/startPage.ejs
@@ -1,0 +1,20 @@
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">DfE Sign-in Service Onboarding Wizard</h1>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">This service will guide you through the process of onboarding a new service to DfE Sign-in.</p>
+
+            <a href="" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+                Start now
+                <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                </svg>
+            </a>            
+        </div>
+    </div>
+</div>

--- a/src/app/services/views/dashboard.ejs
+++ b/src/app/services/views/dashboard.ejs
@@ -141,7 +141,7 @@
                         <a id="onboard-service" class="govuk-link-bold" href="/onboarding/<%= locals.serviceId %>/service">Onboard a service</a>
                     </h3>
                     <p class="govuk-body">
-                        Onboard a new service to DfE Sign-in. (Currently under construction)
+                        Onboard a new service to DfE Sign-in.
                     </p>
                 </div>
                 <% } %>

--- a/src/app/services/views/dashboard.ejs
+++ b/src/app/services/views/dashboard.ejs
@@ -138,7 +138,7 @@
                 <% if (locals.userRoles.includes('onboardSvc')) { %>
                 <div class="manage-card">
                     <h3 class="govuk-heading-s">
-                        <a id="onboard-service" class="govuk-link-bold" href="/onboarding/service">Onboard a service</a>
+                        <a id="onboard-service" class="govuk-link-bold" href="/onboarding/<%= locals.serviceId %>/service">Onboard a service</a>
                     </h3>
                     <p class="govuk-body">
                         Onboard a new service to DfE Sign-in. (Currently under construction)

--- a/src/app/services/views/dashboard.ejs
+++ b/src/app/services/views/dashboard.ejs
@@ -135,10 +135,10 @@
                 </div>
                 <% } %>
 
-                <% if (locals.userRoles.includes('onboarding')) { %>
+                <% if (locals.userRoles.includes('onboardSvc')) { %>
                 <div class="manage-card">
                     <h3 class="govuk-heading-s">
-                        <a id="service-onboard" class="govuk-link-bold" href="<%= locals.serviceId %>/onboarding">Onboard a service</a>
+                        <a id="onboard-service" class="govuk-link-bold" href="/onboarding/service">Onboard a service</a>
                     </h3>
                     <p class="govuk-body">
                         Onboard a new service to DfE Sign-in. (Currently under construction)

--- a/src/app/services/views/dashboard.ejs
+++ b/src/app/services/views/dashboard.ejs
@@ -134,6 +134,18 @@
                     </p>
                 </div>
                 <% } %>
+
+                <% if (locals.userRoles.includes('onboarding')) { %>
+                <div class="manage-card">
+                    <h3 class="govuk-heading-s">
+                        <a id="service-onboard" class="govuk-link-bold" href="<%= locals.serviceId %>/onboarding">Onboard a service</a>
+                    </h3>
+                    <p class="govuk-body">
+                        Onboard a new service to DfE Sign-in. (Currently under construction)
+                    </p>
+                </div>
+                <% } %>
+
             </div>
         </div>
     </div>

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,7 @@
-const config = require('./infrastructure/config');
 const healthCheck = require('login.dfe.healthcheck');
+const config = require('./infrastructure/config');
 const services = require('./app/services');
+const onboarding = require('./app/onboarding');
 const signOut = require('./app/signOut');
 
 const routes = (app, csrf) => {
@@ -13,6 +14,8 @@ const routes = (app, csrf) => {
   app.get('/', (req, res) => {
     res.redirect('/services');
   });
+
+  app.use('/onboarding', onboarding(csrf));
 
   app.use('/signout', signOut(csrf));
 


### PR DESCRIPTION
Implementation for: https://dfe-secureaccess.atlassian.net/browse/NSA-7172

Adds the following for users with a service onboarding role:
- Navigation bar link to the onboarding wizard.
- Tile in the service dashboard for the onboarding wizard.
- Basic start page for the onboarding wizard.

This adds a new directory to the `src/app/` directory called `onboarding` where all work relating to the onboarding wizard will be written.