### PR TITLE
[NSA-7220] Improve select service speed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,8 @@
     "strict": "off",
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "max-len": 0
+  },
+  "env": {
+    "jest": true
   }
 }

--- a/src/app/services/selectService.js
+++ b/src/app/services/selectService.js
@@ -57,7 +57,11 @@ const validate = async (req) => {
     selectedService,
     validationMessages: {},
   };
-  if (model.selectedService === undefined || model.selectedService === null) {
+  if (
+    model.selectedService === undefined
+    || model.selectedService === null
+    || typeof userServices.find((service) => service.id === model.selectedService) === 'undefined'
+  ) {
     model.validationMessages.selectedService = 'Please select a service';
   }
   return model;

--- a/src/app/services/selectService.js
+++ b/src/app/services/selectService.js
@@ -1,24 +1,34 @@
 'use strict';
 
-const uniqBy = require('lodash/uniqBy');
 const sortBy = require('lodash/sortBy');
-const { getServiceById } = require('../../infrastructure/applications');
+const chunk = require('lodash/chunk');
+const { getServiceSummaries } = require('../../infrastructure/applications');
+const logger = require('../../infrastructure/logger');
 
 const getServiceDetails = async (req) => {
-  let userServices = req.userServices.roles.map((role) => ({
-    id: role.code.substr(0, role.code.indexOf('_')),
-    name: '',
-  }));
+  // Unique service IDs obtained from the user's manage roles.
+  const userServicesIds = new Set(req.userServices.roles.map((role) => role.code.substr(0, role.code.indexOf('_'))));
+  // Group service IDs into requests (promises) to get their summaries.
+  const groupedServices = chunk([...userServicesIds], 33);
+  const requests = groupedServices.map((x) => getServiceSummaries(x, ['id', 'name', 'description'], req.id));
+  // Wait for all requests to complete or one to fail.
+  const responses = await Promise.all(requests);
+  // Get services from responses.
+  const services = responses.map((response) => {
+    let responseServices = [];
+    if (response !== null) {
+      responseServices = response.services ? response.services : [response];
+    }
+    return responseServices;
+  }).flat();
 
-  userServices = uniqBy(userServices, 'id');
-
-  for (let i = 0; i < userServices.length; i++) {
-    const service = userServices[i];
-    const application = await getServiceById(service.id, req.id);
-    service.name = application.name;
-    service.description = application.description;
+  if (services.length === 0) {
+    const message = `No manage services found with IDs [${[...userServicesIds].join()}]`;
+    logger.error(message, { correlationId: req.id });
+    throw new Error(`${message}, correlation ID ${req.id}`);
   }
-  return sortBy(userServices, 'name');
+
+  return sortBy(services, 'name');
 };
 
 const get = async (req, res) => {

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -4,7 +4,6 @@ const rp = require('login.dfe.request-promise-retry');
 
 const jwtStrategy = require('login.dfe.jwt-strategies');
 
-
 const callApi = async (endpoint, method, body, correlationId) => {
   const token = await jwtStrategy(config.applications.service).getBearerToken();
 
@@ -35,6 +34,13 @@ const callApi = async (endpoint, method, body, correlationId) => {
 const getServiceById = async (id, correlationId) => {
   return await callApi(`services/${id}`, 'GET', undefined, correlationId);
 };
+
+const getServiceSummaries = async (ids, fields, correlationId) => callApi(
+  `service-summaries/${ids.join()}?fields=${fields.join()}`,
+  'GET',
+  undefined,
+  correlationId,
+);
 
 const listAllServices = async (correlationId) => {
   return await callApi(`services`, 'GET', undefined, correlationId);
@@ -113,6 +119,7 @@ const removeBanner = async (sid, bid, correlationId) => {
 
 module.exports = {
   getServiceById,
+  getServiceSummaries,
   updateService,
   listAllServices,
   listBannersForService,

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -1,21 +1,19 @@
-const config = require('./../config');
-
 const rp = require('login.dfe.request-promise-retry');
-
 const jwtStrategy = require('login.dfe.jwt-strategies');
+const config = require('../config');
 
 const callApi = async (endpoint, method, body, correlationId) => {
   const token = await jwtStrategy(config.applications.service).getBearerToken();
 
   try {
     return await rp({
-      method: method,
+      method,
       uri: `${config.applications.service.url}/${endpoint}`,
       headers: {
         authorization: `bearer ${token}`,
         'x-correlation-id': correlationId,
       },
-      body: body,
+      body,
       json: true,
       strictSSL: config.hostingEnvironment.env.toLowerCase() !== 'dev',
     });
@@ -31,9 +29,7 @@ const callApi = async (endpoint, method, body, correlationId) => {
   }
 };
 
-const getServiceById = async (id, correlationId) => {
-  return await callApi(`services/${id}`, 'GET', undefined, correlationId);
-};
+const getServiceById = async (id, correlationId) => callApi(`services/${id}`, 'GET', undefined, correlationId);
 
 const getServiceSummaries = async (ids, fields, correlationId) => callApi(
   `service-summaries/${ids.join()}?fields=${fields.join()}`,
@@ -42,39 +38,36 @@ const getServiceSummaries = async (ids, fields, correlationId) => callApi(
   correlationId,
 );
 
-const listAllServices = async (correlationId) => {
-  return await callApi(`services`, 'GET', undefined, correlationId);
-};
+const listAllServices = async (correlationId) => callApi('services', 'GET', undefined, correlationId);
 
 const updateService = async (id, serviceDetails, correlationId) => {
   const body = {};
   if (serviceDetails.name) {
-    body.name = serviceDetails.name
+    body.name = serviceDetails.name;
   }
-
   if (serviceDetails.serviceHome) {
-    body.serviceHome = serviceDetails.serviceHome
+    body.serviceHome = serviceDetails.serviceHome;
   }
   if (serviceDetails.clientId) {
-    body.clientId = serviceDetails.clientId
+    body.clientId = serviceDetails.clientId;
   }
   if (serviceDetails.clientSecret) {
-    body.clientSecret = serviceDetails.clientSecret
+    body.clientSecret = serviceDetails.clientSecret;
   }
   if (serviceDetails.redirect_uris) {
-    body.redirect_uris = serviceDetails.redirect_uris
+    body.redirect_uris = serviceDetails.redirect_uris;
   }
   if (serviceDetails.post_logout_redirect_uris) {
-    body.post_logout_redirect_uris = serviceDetails.post_logout_redirect_uris
+    body.post_logout_redirect_uris = serviceDetails.post_logout_redirect_uris;
   }
   if (serviceDetails.grant_types) {
-    body.grant_types = serviceDetails.grant_types
+    body.grant_types = serviceDetails.grant_types;
   }
   if (serviceDetails.response_types) {
-    body.response_types = serviceDetails.response_types
+    body.response_types = serviceDetails.response_types;
   }
   if (serviceDetails.apiSecret) {
-    body.apiSecret = serviceDetails.apiSecret
+    body.apiSecret = serviceDetails.apiSecret;
   }
   if (serviceDetails.description) {
     body.description = serviceDetails.description;
@@ -82,12 +75,15 @@ const updateService = async (id, serviceDetails, correlationId) => {
   body.tokenEndpointAuthMethod = serviceDetails.tokenEndpointAuthMethod ? serviceDetails.tokenEndpointAuthMethod : null;
   body.postResetUrl = serviceDetails.postResetUrl ? serviceDetails.postResetUrl : null;
 
-  return await callApi(`services/${id}`, 'PATCH', body, correlationId);
+  return callApi(`services/${id}`, 'PATCH', body, correlationId);
 };
 
-const listBannersForService = async (id, pageSize, page, correlationId) => {
-  return await callApi(`services/${id}/banners?pageSize=${pageSize}?&page=${page}`, 'GET', undefined, correlationId);
-};
+const listBannersForService = async (id, pageSize, page, correlationId) => callApi(
+  `services/${id}/banners?pageSize=${pageSize}?&page=${page}`,
+  'GET',
+  undefined,
+  correlationId,
+);
 
 const listAllBannersForService = async (id, correlationId) => {
   const allBanners = [];
@@ -99,23 +95,32 @@ const listAllBannersForService = async (id, correlationId) => {
     page.banners.forEach((banner) => {
       allBanners.push(banner);
     });
-    pageNumber ++;
+    pageNumber += 1;
     isMorePages = pageNumber <= page.totalNumberOfPages;
   }
   return allBanners;
 };
 
-const getBannerById = async (id, bid, correlationId) => {
-  return await callApi(`services/${id}/banners/${bid}`, 'GET', undefined, correlationId);
-};
+const getBannerById = async (id, bid, correlationId) => callApi(
+  `services/${id}/banners/${bid}`,
+  'GET',
+  undefined,
+  correlationId,
+);
 
-const upsertBanner = async (sid, banner, correlationId) => {
-  return await callApi(`services/${sid}/banners`, 'POST', banner, correlationId);
-};
+const upsertBanner = async (sid, banner, correlationId) => callApi(
+  `services/${sid}/banners`,
+  'POST',
+  banner,
+  correlationId,
+);
 
-const removeBanner = async (sid, bid, correlationId) => {
-  return await  callApi(`services/${sid}/banners/${bid}`, 'DELETE', undefined, correlationId);
-};
+const removeBanner = async (sid, bid, correlationId) => callApi(
+  `services/${sid}/banners/${bid}`,
+  'DELETE',
+  undefined,
+  correlationId,
+);
 
 module.exports = {
   getServiceById,

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -91,7 +91,7 @@ const listAllBannersForService = async (id, correlationId) => {
   let pageNumber = 1;
   let isMorePages = true;
   while (isMorePages) {
-    const page = await listBannersForService(id, 25, pageNumber ,correlationId);
+    const page = await listBannersForService(id, 25, pageNumber, correlationId);
     page.banners.forEach((banner) => {
       allBanners.push(banner);
     });

--- a/src/infrastructure/applications/static.js
+++ b/src/infrastructure/applications/static.js
@@ -53,9 +53,10 @@ const mapServiceFieldsToAttributes = (fields) => fields.map((field) => {
   return mappedField;
 });
 
-const getServiceById = async (idOrClientId, correlationId) => {
-  return applications.find(a => a.id.toLowerCase() === idOrClientId.toLowerCase() || (a.relyingParty && a.relyingParty.clientId.toLowerCase() === idOrClientId.toLowerCase()));
-};
+const getServiceById = async (idOrClientId, correlationId) => applications.find(
+  (a) => a.id.toLowerCase() === idOrClientId.toLowerCase()
+  || (a.relyingParty && a.relyingParty.clientId.toLowerCase() === idOrClientId.toLowerCase()),
+);
 
 const getServiceSummaries = async (ids, fields, correlationId) => {
   const lowercaseIds = ids.map((id) => id.toLowerCase());
@@ -79,44 +80,32 @@ const getServiceSummaries = async (ids, fields, correlationId) => {
   });
 };
 
-const updateService = async (id, body, correlationId) => {
-  return Promise.resolve(null);
-};
+const updateService = async (id, body, correlationId) => Promise.resolve(null);
 
-const listAllServices = async (correlationId) => {
-  return Promise.resolve(null);
-};
+const listAllServices = async (correlationId) => Promise.resolve(null);
 
-const listBannersForService = async (id, pageSize, page, correlationId) => {
-  return Promise.resolve({
-    banners: {
-      id: 'bannerId',
-      serviceId: 'serviceId',
-      name: 'banner name',
-      title: 'banner title',
-      message: 'banner message',
-    },
-    page: page,
-    totalNumberOfPages: 1,
-    totalNumberOfRecords: 1,
-  });
-};
+const listBannersForService = async (id, pageSize, page, correlationId) => Promise.resolve({
+  banners: {
+    id: 'bannerId',
+    serviceId: 'serviceId',
+    name: 'banner name',
+    title: 'banner title',
+    message: 'banner message',
+  },
+  page,
+  totalNumberOfPages: 1,
+  totalNumberOfRecords: 1,
+});
 
-const getBannerById = async (id, bid, correlationId) => {
-  return Promise.resolve(null);
-};
+const getBannerById = async (id, bid, correlationId) => Promise.resolve(null);
 
-const upsertBanner = async (sid, banner, correlationId) => {
-  return Promise.resolve(null);
-};
+const upsertBanner = async (sid, banner, correlationId) => Promise.resolve(null);
 
-const removeBanner = async (sid, bid, correlationId) => {
-  return Promise.resolve(null);
-};
+const removeBanner = async (sid, bid, correlationId) => Promise.resolve(null);
 
-const listAllBannersForService = async (id, correlationId) => {
-  return (await listBannersForService(id, 25, 1, correlationId).banners.find(x => x.id === id))
-};
+const listAllBannersForService = async (id, correlationId) => listBannersForService(id, 25, 1, correlationId)
+  .banners
+  .find((x) => x.id === id);
 
 module.exports = {
   getServiceById,

--- a/src/infrastructure/applications/static.js
+++ b/src/infrastructure/applications/static.js
@@ -1,7 +1,82 @@
 const applications = [];
 
+const mapServiceFieldsToAttributes = (fields) => fields.map((field) => {
+  let mappedField = '';
+  switch (field) {
+    case 'id':
+    case 'name':
+    case 'description':
+    case 'isExternalService':
+    case 'isMigrated':
+    case 'parentId':
+      mappedField = field;
+      break;
+    case 'assertions':
+      mappedField = 'saml';
+      break;
+    case 'clientId':
+      mappedField = 'relyingParty.client_id';
+      break;
+    case 'clientSecret':
+      mappedField = 'relyingParty.client_secret';
+      break;
+    case 'apiSecret':
+      mappedField = 'relyingParty.api_secret';
+      break;
+    case 'tokenEndpointAuthMethod':
+      mappedField = 'relyingParty.token_endpoint_auth_method';
+      break;
+    case 'serviceHome':
+      mappedField = 'relyingParty.service_home';
+      break;
+    case 'postResetUrl':
+      mappedField = 'relyingParty.postResetUrl';
+      break;
+    case 'redirects':
+      mappedField = 'relyingParty.redirect_uris';
+      break;
+    case 'postLogoutRedirects':
+      mappedField = 'relyingParty.post_logout_redirect_uris';
+      break;
+    case 'grantTypes':
+      mappedField = 'relyingParty.grant_types';
+      break;
+    case 'responseTypes':
+      mappedField = 'relyingParty.response_types';
+      break;
+    case 'params':
+      mappedField = 'relyingParty.params';
+      break;
+    default:
+      mappedField = '';
+  }
+  return mappedField;
+});
+
 const getServiceById = async (idOrClientId, correlationId) => {
   return applications.find(a => a.id.toLowerCase() === idOrClientId.toLowerCase() || (a.relyingParty && a.relyingParty.clientId.toLowerCase() === idOrClientId.toLowerCase()));
+};
+
+const getServiceSummaries = async (ids, fields, correlationId) => {
+  const lowercaseIds = ids.map((id) => id.toLowerCase());
+  const foundApps = applications.filter((a) => lowercaseIds.includes(a.id.toLowerCase())
+    || (a.relyingParty && lowercaseIds.includes(a.relyingParty.clientId.toLowerCase())));
+  const requiredAttributes = mapServiceFieldsToAttributes(fields);
+  return foundApps.map((app) => {
+    const appWithAttributes = {};
+    requiredAttributes.forEach((field) => {
+      const splitField = field.split('.');
+      if (splitField.length === 1) {
+        appWithAttributes[splitField] = app[splitField];
+      } else {
+        if (typeof appWithAttributes[splitField[0]] === 'undefined') {
+          appWithAttributes[splitField[0]] = {};
+        }
+        appWithAttributes[splitField[0]][splitField[1]] = app[splitField[0]][splitField[1]];
+      }
+    });
+    return appWithAttributes;
+  });
 };
 
 const updateService = async (id, body, correlationId) => {
@@ -45,6 +120,7 @@ const listAllBannersForService = async (id, correlationId) => {
 
 module.exports = {
   getServiceById,
+  getServiceSummaries,
   updateService,
   listAllServices,
   listBannersForService,

--- a/src/infrastructure/applications/static.js
+++ b/src/infrastructure/applications/static.js
@@ -63,7 +63,7 @@ const getServiceSummaries = async (ids, fields, correlationId) => {
   const foundApps = applications.filter((a) => lowercaseIds.includes(a.id.toLowerCase())
     || (a.relyingParty && lowercaseIds.includes(a.relyingParty.clientId.toLowerCase())));
   const requiredAttributes = mapServiceFieldsToAttributes(fields);
-  return foundApps.map((app) => {
+  return [...new Set(foundApps.map((app) => {
     const appWithAttributes = {};
     requiredAttributes.forEach((field) => {
       const splitField = field.split('.');
@@ -77,7 +77,7 @@ const getServiceSummaries = async (ids, fields, correlationId) => {
       }
     });
     return appWithAttributes;
-  });
+  }))];
 };
 
 const updateService = async (id, body, correlationId) => Promise.resolve(null);

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -31,15 +31,11 @@ describe('When going to the select-service page', () => {
     });
 
     getServiceById.mockReset();
-    getServiceById.mockReturnValue([{
+    getServiceById.mockReturnValue({
       id: 'serviceid',
       name: 'service one',
       description: 'service one description',
-    }], [{
-      id: 'serviceid1',
-      name: 'service two',
-      description: 'service two description',
-    }]);
+    });
     res.mockResetAll();
   });
 

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -48,12 +48,13 @@ describe('When going to the select-service page', () => {
     res.mockResetAll();
   });
 
-  it('then it should get the services by id', async () => {
+  it('Then it should get the necessary service information with one request if the user has <=33 services', async () => {
     await getSelectService(req, res);
 
-    expect(getServiceSummaries.mock.calls).toHaveLength(2);
-    expect(getServiceSummaries.mock.calls[0][0]).toBe('serviceid');
-    expect(getServiceSummaries.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceSummaries.mock.calls).toHaveLength(1);
+    expect(getServiceSummaries.mock.calls[0][0]).toStrictEqual(['serviceid', 'serviceid1']);
+    expect(getServiceSummaries.mock.calls[0][1]).toStrictEqual(['id', 'name', 'description']);
+    expect(getServiceSummaries.mock.calls[0][2]).toBe('correlationId');
   });
 
   it('then it should redirect to the service if only one service', async () => {
@@ -62,6 +63,11 @@ describe('When going to the select-service page', () => {
         code: 'serviceid_serviceconfiguration',
       }],
     };
+    getServiceSummaries.mockReturnValue({
+      id: 'serviceid',
+      name: 'service one',
+      description: 'service one description',
+    });
     await getSelectService(req, res);
 
     expect(res.redirect.mock.calls).toHaveLength(1);

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -1,63 +1,49 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
+const mockUtils = require('../../utils');
+
+const mockConfig = mockUtils.configMockFactory();
+const mockLogger = mockUtils.loggerMockFactory();
+
+jest.mock('./../../../src/infrastructure/config', () => mockConfig);
+jest.mock('./../../../src/infrastructure/logger', () => mockLogger);
 jest.mock('./../../../src/infrastructure/applications');
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const getSelectService = require('./../../../src/app/services/selectService').get;
-const { getServiceById } = require('./../../../src/infrastructure/applications');
+const { getRequestMock, getResponseMock } = require('../../utils');
+const getSelectService = require('../../../src/app/services/selectService').get;
+const { getServiceById } = require('../../../src/infrastructure/applications');
+
 const res = getResponseMock();
 
-describe('when getting the select service page', () => {
+describe('When going to the select-service page', () => {
   let req;
 
   beforeEach(() => {
     req = getRequestMock({
-      params: {
-        sid: 'service1'
-      },
       userServices: {
         roles: [
           {
-          code: 'serviceid_serviceconfiguration'
+            code: 'serviceid_serviceconfig',
           },
           {
-            code: 'serviceid1_serviceconfiguration'
+            code: 'serviceid1_serviceconfig',
           },
-
-        ]
+        ],
       },
     });
 
     getServiceById.mockReset();
-    getServiceById.mockReturnValue({
+    getServiceById.mockReturnValue([{
       id: 'serviceid',
       name: 'service one',
-      description: 'service description',
-      relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code'
-        ],
-        response_types: [
-          'code',
-        ],
-      }
-    });
+      description: 'service one description',
+    }], [{
+      id: 'serviceid1',
+      name: 'service two',
+      description: 'service two description',
+    }]);
     res.mockResetAll();
   });
-  it('then it should get the services by id', async () => {
 
+  it('then it should get the services by id', async () => {
     await getSelectService(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(2);
@@ -66,15 +52,15 @@ describe('when getting the select service page', () => {
   });
 
   it('then it should redirect to the service if only one service', async () => {
-    req.userServices= {
+    req.userServices = {
       roles: [{
-        code: 'serviceid_serviceconfiguration'
-      }]
+        code: 'serviceid_serviceconfiguration',
+      }],
     };
     await getSelectService(req, res);
 
     expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`serviceid`);
+    expect(res.redirect.mock.calls[0][0]).toBe('serviceid');
   });
 
   it('then it should return the multiple services view', async () => {
@@ -98,12 +84,12 @@ describe('when getting the select service page', () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       services: [
         {
-        id: 'serviceid',
-        name: 'service one'
+          id: 'serviceid',
+          name: 'service one',
         },
         {
           id: 'serviceid1',
-          name: 'service one'
+          name: 'service one',
         },
       ],
     });

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -9,7 +9,7 @@ jest.mock('./../../../src/infrastructure/applications');
 
 const { getRequestMock, getResponseMock } = require('../../utils');
 const getSelectService = require('../../../src/app/services/selectService').get;
-const { getServiceById } = require('../../../src/infrastructure/applications');
+const { getServiceSummaries } = require('../../../src/infrastructure/applications');
 
 const res = getResponseMock();
 
@@ -30,11 +30,20 @@ describe('When going to the select-service page', () => {
       },
     });
 
-    getServiceById.mockReset();
-    getServiceById.mockReturnValue({
-      id: 'serviceid',
-      name: 'service one',
-      description: 'service one description',
+    getServiceSummaries.mockReset();
+    getServiceSummaries.mockReturnValue({
+      services: [
+        {
+          id: 'serviceid',
+          name: 'service one',
+          description: 'service one description',
+        },
+        {
+          id: 'serviceid1',
+          name: 'service two',
+          description: 'service two description',
+        },
+      ],
     });
     res.mockResetAll();
   });
@@ -42,9 +51,9 @@ describe('When going to the select-service page', () => {
   it('then it should get the services by id', async () => {
     await getSelectService(req, res);
 
-    expect(getServiceById.mock.calls).toHaveLength(2);
-    expect(getServiceById.mock.calls[0][0]).toBe('serviceid');
-    expect(getServiceById.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceSummaries.mock.calls).toHaveLength(2);
+    expect(getServiceSummaries.mock.calls[0][0]).toBe('serviceid');
+    expect(getServiceSummaries.mock.calls[0][1]).toBe('correlationId');
   });
 
   it('then it should redirect to the service if only one service', async () => {
@@ -82,10 +91,12 @@ describe('When going to the select-service page', () => {
         {
           id: 'serviceid',
           name: 'service one',
+          description: 'service one description',
         },
         {
           id: 'serviceid1',
-          name: 'service one',
+          name: 'service two',
+          description: 'service two description',
         },
       ],
     });

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -74,6 +74,18 @@ describe('When going to the select-service page', () => {
     expect(getServiceSummaries.mock.calls[1][2]).toBe('correlationId');
   });
 
+  it('Then it should log and throw an error if no active services could be found for the user', async () => {
+    const userServicesIds = new Set(req.userServices.roles.map((role) => role.code.substr(0, role.code.indexOf('_'))));
+    const expectedMessage = `No manage services found with IDs [${[...userServicesIds].join()}]`;
+
+    getServiceSummaries.mockReturnValue(null);
+
+    await expect(async () => getSelectService(req, res)).rejects.toThrow(`${expectedMessage}, correlation ID ${req.id}`);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error.mock.calls[0][0]).toBe(expectedMessage);
+    expect(mockLogger.error.mock.calls[0][1]).toStrictEqual({ correlationId: req.id });
+  });
+
   it('Then it should redirect to the service dashboard if the user only has one active service', async () => {
     req.userServices = {
       roles: [{

--- a/test/app/services/getSelectService.test.js
+++ b/test/app/services/getSelectService.test.js
@@ -74,10 +74,10 @@ describe('When going to the select-service page', () => {
     expect(getServiceSummaries.mock.calls[1][2]).toBe('correlationId');
   });
 
-  it('then it should redirect to the service if only one service', async () => {
+  it('Then it should redirect to the service dashboard if the user only has one active service', async () => {
     req.userServices = {
       roles: [{
-        code: 'serviceid_serviceconfiguration',
+        code: 'serviceid_serviceconfig',
       }],
     };
     getServiceSummaries.mockReturnValue({
@@ -91,14 +91,14 @@ describe('When going to the select-service page', () => {
     expect(res.redirect.mock.calls[0][0]).toBe('serviceid');
   });
 
-  it('then it should return the multiple services view', async () => {
+  it('Then it should return the selectService view if the user has more than one active service', async () => {
     await getSelectService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
     expect(res.render.mock.calls[0][0]).toBe('services/views/selectService');
   });
 
-  it('then it should include csrf token in model', async () => {
+  it('Then it should include csrf token in model', async () => {
     await getSelectService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
@@ -106,7 +106,7 @@ describe('When going to the select-service page', () => {
     });
   });
 
-  it('then it should include the service details in the model', async () => {
+  it('Then it should include the service details in the model', async () => {
     await getSelectService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -13,7 +13,7 @@ const { getServiceSummaries } = require('../../../src/infrastructure/application
 
 const res = getResponseMock();
 
-describe('when selecting a service', () => {
+describe('When selecting a service', () => {
   let req;
 
   beforeEach(() => {
@@ -46,7 +46,7 @@ describe('when selecting a service', () => {
     res.mockResetAll();
   });
 
-  it('then it should render validation message if no selected service', async () => {
+  it('Then it should render a validation message if no service is selected', async () => {
     req.body.selectedService = undefined;
 
     await postSelectService(req, res);
@@ -74,7 +74,7 @@ describe('when selecting a service', () => {
     });
   });
 
-  it('then it should redirect to the selected organisation if not undefined', async () => {
+  it('Then it should redirect to the selected service dashboard if selectedService is defined', async () => {
     req.body.selectedService = 'service1';
     await postSelectService(req, res);
     expect(res.redirect.mock.calls).toHaveLength(1);

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -52,25 +52,8 @@ describe('When selecting a service', () => {
     await postSelectService(req, res);
     expect(res.render.mock.calls).toHaveLength(1);
     expect(res.render.mock.calls[0][0]).toBe('services/views/selectService');
-    expect(res.render.mock.calls[0][1]).toEqual({
-      csrfToken: 'token',
-      selectedService: undefined,
-      services: [
-        {
-          id: 'serviceid',
-          name: 'service one',
-          description: 'service one description',
-        },
-        {
-          id: 'serviceid1',
-          name: 'service two',
-          description: 'service two description',
-        },
-      ],
-      title: 'Select service',
-      validationMessages: {
-        selectedService: 'Please select a service',
-      },
+    expect(res.render.mock.calls[0][1]).toHaveProperty('validationMessages', {
+      selectedService: 'Please select a service',
     });
   });
 

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -1,10 +1,16 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
+const mockUtils = require('../../utils');
+
+const mockConfig = mockUtils.configMockFactory();
+const mockLogger = mockUtils.loggerMockFactory();
+
+jest.mock('./../../../src/infrastructure/config', () => mockConfig);
+jest.mock('./../../../src/infrastructure/logger', () => mockLogger);
 jest.mock('./../../../src/infrastructure/applications');
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const postSelectService = require('./../../../src/app/services/selectService').post;
-const { getServiceById } = require('./../../../src/infrastructure/applications');
+const { getRequestMock, getResponseMock } = require('../../utils');
+const postSelectService = require('../../../src/app/services/selectService').post;
+const { getServiceById } = require('../../../src/infrastructure/applications');
+
 const res = getResponseMock();
 
 describe('when selecting a service', () => {
@@ -13,12 +19,12 @@ describe('when selecting a service', () => {
   beforeEach(() => {
     req = getRequestMock({
       params: {
-        sid: 'service1'
+        sid: 'service1',
       },
       userServices: {
         roles: [{
-          code: 'serviceid_serviceconfiguration'
-        }]
+          code: 'serviceid_serviceconfiguration',
+        }],
       },
     });
 
@@ -27,26 +33,6 @@ describe('when selecting a service', () => {
       id: 'serviceid',
       name: 'service one',
       description: 'service description',
-      relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code'
-        ],
-        response_types: [
-          'code',
-        ],
-      }
     });
     res.mockResetAll();
   });
@@ -56,7 +42,7 @@ describe('when selecting a service', () => {
 
     await postSelectService(req, res);
     expect(res.render.mock.calls).toHaveLength(1);
-    expect(res.render.mock.calls[0][0]).toBe(`services/views/selectService`);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/selectService');
     expect(res.render.mock.calls[0][1]).toEqual({
       csrfToken: 'token',
       selectedService: undefined,

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -74,8 +74,8 @@ describe('When selecting a service', () => {
     });
   });
 
-  it('Then it should redirect to the selected service dashboard if selectedService is defined', async () => {
-    req.body.selectedService = 'service1';
+  it('Then it should redirect to the selected service dashboard if selectedService is defined and is in the services list', async () => {
+    req.body.selectedService = 'serviceid';
     await postSelectService(req, res);
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.body.selectedService}`);

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -57,6 +57,17 @@ describe('When selecting a service', () => {
     });
   });
 
+  it('Then it should render a validation message if selectedService is defined but is not in the services list', async () => {
+    req.body.selectedService = 'non-existant-id';
+
+    await postSelectService(req, res);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('services/views/selectService');
+    expect(res.render.mock.calls[0][1]).toHaveProperty('validationMessages', {
+      selectedService: 'Please select a service',
+    });
+  });
+
   it('Then it should redirect to the selected service dashboard if selectedService is defined and is in the services list', async () => {
     req.body.selectedService = 'serviceid';
     await postSelectService(req, res);

--- a/test/app/services/postSelectService.test.js
+++ b/test/app/services/postSelectService.test.js
@@ -9,7 +9,7 @@ jest.mock('./../../../src/infrastructure/applications');
 
 const { getRequestMock, getResponseMock } = require('../../utils');
 const postSelectService = require('../../../src/app/services/selectService').post;
-const { getServiceById } = require('../../../src/infrastructure/applications');
+const { getServiceSummaries } = require('../../../src/infrastructure/applications');
 
 const res = getResponseMock();
 
@@ -28,11 +28,20 @@ describe('when selecting a service', () => {
       },
     });
 
-    getServiceById.mockReset();
-    getServiceById.mockReturnValue({
-      id: 'serviceid',
-      name: 'service one',
-      description: 'service description',
+    getServiceSummaries.mockReset();
+    getServiceSummaries.mockReturnValue({
+      services: [
+        {
+          id: 'serviceid',
+          name: 'service one',
+          description: 'service one description',
+        },
+        {
+          id: 'serviceid1',
+          name: 'service two',
+          description: 'service two description',
+        },
+      ],
     });
     res.mockResetAll();
   });
@@ -46,11 +55,18 @@ describe('when selecting a service', () => {
     expect(res.render.mock.calls[0][1]).toEqual({
       csrfToken: 'token',
       selectedService: undefined,
-      services: [{
-        id: 'serviceid',
-        name: 'service one',
-        description: 'service description',
-      }],
+      services: [
+        {
+          id: 'serviceid',
+          name: 'service one',
+          description: 'service one description',
+        },
+        {
+          id: 'serviceid1',
+          name: 'service two',
+          description: 'service two description',
+        },
+      ],
       title: 'Select service',
       validationMessages: {
         selectedService: 'Please select a service',


### PR DESCRIPTION
This PR includes the following changes:

- A new implementation for the selectService getServiceDetails function to get information for multiple services at once, and only retrieve the id, name, and description for them.
- Updated selectService validation to give an error message if the selectedService variable isn't an option from their list.
- Added the getServiceSummaries function to the applications API/static infra files, which will be replacing getServiceById in the near future.
- Various ESLint fixes.