### PR TITLE
[NSA-6469] Enhance service config change logging

### DIFF
--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -159,6 +159,22 @@ const postServiceConfig = async (req, res) => {
     return res.render('services/views/serviceConfig', model);
   }
 
+  const editedFields = Object.entries(currentService).filter(([field, oldValue]) => {
+    const newValue = model.service[field];
+    return Array.isArray(oldValue) ? !(
+      Array.isArray(newValue)
+      && oldValue.length === newValue.length
+      && oldValue.every((value, index) => value === newValue[index])
+    ) : oldValue !== newValue;
+  }).map(([field, oldValue]) => {
+    const isSecret = field.toLowerCase().includes('secret');
+    return {
+      name: field,
+      oldValue: isSecret ? 'EXPUNGED' : oldValue,
+      newValue: isSecret ? 'EXPUNGED' : model.service[field],
+    };
+  });
+
   const updatedService = {
     name: model.service.name,
     description: model.service.description,
@@ -180,6 +196,7 @@ const postServiceConfig = async (req, res) => {
     userId: req.user.sub,
     userEmail: req.user.email,
     editedService: req.params.sid,
+    editedFields,
   });
 
   await updateService(req.params.sid, updatedService, req.id);

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -161,11 +161,11 @@ const postServiceConfig = async (req, res) => {
   }
 
   const editedFields = Object.entries(currentService).filter(([field, oldValue]) => {
-    const newValue = model.service[field];
+    const newValue = Array.isArray(model.service[field]) ? model.service[field].sort() : model.service[field];
     return Array.isArray(oldValue) ? !(
       Array.isArray(newValue)
       && oldValue.length === newValue.length
-      && oldValue.every((value, index) => value === newValue[index])
+      && oldValue.sort().every((value, index) => value === newValue[index])
     ) : oldValue !== newValue;
   }).map(([field, oldValue]) => {
     const isSecret = field.toLowerCase().includes('secret');

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -10,14 +10,14 @@ const buildCurrentServiceModel = async (req) => {
   return {
     name: service.name || '',
     description: service.description || '',
-    serviceHome: service.relyingParty.service_home || '',
-    postResetUrl: service.relyingParty.postResetUrl || '',
     clientId: service.relyingParty.client_id || '',
     clientSecret: service.relyingParty.client_secret || '',
+    serviceHome: service.relyingParty.service_home || '',
+    postResetUrl: service.relyingParty.postResetUrl || '',
     redirectUris: service.relyingParty.redirect_uris || [],
     postLogoutRedirectUris: service.relyingParty.post_logout_redirect_uris || [],
-    responseTypes: service.relyingParty.response_types || [],
     grantTypes: service.relyingParty.grant_types || [],
+    responseTypes: service.relyingParty.response_types || [],
     apiSecret: service.relyingParty.api_secret || '',
     tokenEndpointAuthMethod: service.relyingParty.token_endpoint_auth_method,
   };

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -38,7 +38,7 @@ const getServiceConfig = async (req, res) => {
 };
 
 const validate = async (req, currentService) => {
-  const urlValidation = new RegExp('^https?:\\/\\/(.*)');
+  const urlValidation = /^https?:\/\/(.*)/;
   const manageRolesForService = await getUserServiceRoles(req);
 
   let grantTypes = req.body.grant_types ? req.body.grant_types : [];

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -19,7 +19,8 @@ const buildCurrentServiceModel = async (req) => {
     grantTypes: service.relyingParty.grant_types || [],
     responseTypes: service.relyingParty.response_types || [],
     apiSecret: service.relyingParty.api_secret || '',
-    tokenEndpointAuthMethod: service.relyingParty.token_endpoint_auth_method,
+    tokenEndpointAuthMethod: service.relyingParty.token_endpoint_auth_method === 'client_secret_post'
+      ? 'client_secret_post' : null,
   };
 };
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -11,6 +11,7 @@ const logger = require('../../../src/infrastructure/logger');
 
 const res = getResponseMock();
 
+// Represents the getServiceById response.
 const mockCurrentServiceInfo = {
   id: 'service1',
   name: 'service one',
@@ -37,13 +38,17 @@ const mockCurrentServiceInfo = {
     ],
   },
 };
-const mockUpdatedServiceInfo = {
+
+// Represents the request body and the updateService info.
+const mockRequestServiceInfo = {
   name: 'service two',
   description: 'service description',
   clientId: 'clientid2',
   clientSecret: 'outshine-wringing-imparting-submitted',
+  apiSecret: 'outshine-wringing-imparting-submitted',
   serviceHome: 'https://www.servicehome2.com',
   postResetUrl: 'https://www.postreset2.com',
+  tokenEndpointAuthMethod: 'client_secret_post',
   redirect_uris: [
     'https://www.redirect.com',
     'https://www.redirect2.com',
@@ -59,12 +64,28 @@ const mockUpdatedServiceInfo = {
   ],
 };
 
+// Represents the model used for validation and the view.
+const mockModelServiceInfo = {
+  name: mockRequestServiceInfo.name,
+  description: mockCurrentServiceInfo.description,
+  clientId: mockRequestServiceInfo.clientId,
+  clientSecret: mockRequestServiceInfo.clientSecret,
+  serviceHome: mockRequestServiceInfo.serviceHome,
+  postResetUrl: mockRequestServiceInfo.postResetUrl,
+  redirectUris: mockRequestServiceInfo.redirect_uris,
+  postLogoutRedirectUris: mockRequestServiceInfo.post_logout_redirect_uris,
+  grantTypes: mockRequestServiceInfo.grant_types,
+  responseTypes: mockRequestServiceInfo.response_types,
+  apiSecret: mockRequestServiceInfo.apiSecret,
+  tokenEndpointAuthMethod: mockRequestServiceInfo.tokenEndpointAuthMethod,
+};
+
 describe('when editing the service configuration', () => {
   let req;
 
   beforeEach(() => {
     req = getRequestMock({
-      body: { ...mockUpdatedServiceInfo },
+      body: { ...mockRequestServiceInfo },
       params: {
         sid: 'service1',
       },
@@ -87,25 +108,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        clientId: 'clientid2',
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        name: req.body.name,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -126,26 +130,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: 'clientid2',
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'not-a-url',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        serviceHome: req.body.serviceHome,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -166,26 +152,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: undefined,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -207,26 +175,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: testClientId,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -248,26 +198,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: testClientId,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -287,26 +219,8 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls[0][0]).toBe('service1');
 
     expect(updateService.mock.calls[0][1]).toEqual({
-      name: 'service two',
-      description: 'service description',
-      clientId: testClientId,
-      clientSecret: 'outshine-wringing-imparting-submitted',
-      serviceHome: 'https://www.servicehome2.com',
-      postResetUrl: 'https://www.postreset2.com',
-      tokenEndpointAuthMethod: null,
-      redirect_uris: [
-        'https://www.redirect.com',
-        'https://www.redirect2.com',
-      ],
-      post_logout_redirect_uris: [
-        'https://www.logout2.com',
-      ],
-      grant_types: [
-        'implicit',
-      ],
-      response_types: [
-        'code',
-      ],
+      ...mockRequestServiceInfo,
+      clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
   });
@@ -331,26 +245,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: testClientId,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -369,26 +265,8 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
     expect(updateService.mock.calls[0][1]).toEqual({
-      name: 'service two',
-      description: 'service description',
-      clientId: 'cLiEnTiD',
-      clientSecret: 'outshine-wringing-imparting-submitted',
-      serviceHome: 'https://www.servicehome2.com',
-      postResetUrl: 'https://www.postreset2.com',
-      tokenEndpointAuthMethod: null,
-      redirect_uris: [
-        'https://www.redirect.com',
-        'https://www.redirect2.com',
-      ],
-      post_logout_redirect_uris: [
-        'https://www.logout2.com',
-      ],
-      grant_types: [
-        'implicit',
-      ],
-      response_types: [
-        'code',
-      ],
+      ...mockRequestServiceInfo,
+      clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
   });
@@ -402,26 +280,8 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
     expect(updateService.mock.calls[0][1]).toEqual({
-      name: 'service two',
-      description: 'service description',
-      clientId: 'clientid',
-      clientSecret: 'outshine-wringing-imparting-submitted',
-      serviceHome: 'https://www.servicehome2.com',
-      postResetUrl: 'https://www.postreset2.com',
-      tokenEndpointAuthMethod: null,
-      redirect_uris: [
-        'https://www.redirect.com',
-        'https://www.redirect2.com',
-      ],
-      post_logout_redirect_uris: [
-        'https://www.logout2.com',
-      ],
-      grant_types: [
-        'implicit',
-      ],
-      response_types: [
-        'code',
-      ],
+      ...mockRequestServiceInfo,
+      clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
   });
@@ -440,26 +300,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: 'clientid2',
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: null,
+        ...mockModelServiceInfo,
+        redirectUris: req.body.redirect_uris,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -482,26 +324,9 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: testClientId,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
-        tokenEndpointAuthMethod: 'client_secret_post',
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
+        tokenEndpointAuthMethod: req.body.tokenEndpointAuthMethod,
       },
       serviceId: 'service1',
       userRoles: [],
@@ -525,25 +350,8 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        name: 'service two',
-        clientId: testClientId,
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        description: 'service description',
-        grantTypes: [
-          'implicit',
-        ],
-        postLogoutRedirectUris: [
-          'https://www.logout2.com',
-        ],
-        postResetUrl: 'https://www.postreset2.com',
-        redirectUris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        responseTypes: [
-          'code',
-        ],
-        serviceHome: 'https://www.servicehome2.com',
+        ...mockModelServiceInfo,
+        clientId: req.body.clientId,
         tokenEndpointAuthMethod: null,
       },
       serviceId: 'service1',
@@ -560,28 +368,7 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
 
-    expect(updateService.mock.calls[0][1]).toEqual({
-      name: 'service two',
-      description: 'service description',
-      clientId: 'clientid2',
-      clientSecret: 'outshine-wringing-imparting-submitted',
-      serviceHome: 'https://www.servicehome2.com',
-      postResetUrl: 'https://www.postreset2.com',
-      tokenEndpointAuthMethod: null,
-      redirect_uris: [
-        'https://www.redirect.com',
-        'https://www.redirect2.com',
-      ],
-      post_logout_redirect_uris: [
-        'https://www.logout2.com',
-      ],
-      grant_types: [
-        'implicit',
-      ],
-      response_types: [
-        'code',
-      ],
-    });
+    expect(updateService.mock.calls[0][1]).toEqual(mockRequestServiceInfo);
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
   });
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -69,7 +69,7 @@ describe('when editing the service configuration', () => {
 
     updateService.mockReset();
     getServiceById.mockReset();
-    getServiceById.mockReturnValueOnce(mockCurrentServiceInfo).mockReturnValueOnce(null);
+    getServiceById.mockReturnValueOnce({ ...mockCurrentServiceInfo }).mockReturnValueOnce(null);
     res.mockResetAll();
   });
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -19,10 +19,8 @@ const mockCurrentServiceInfo = {
   relyingParty: {
     client_id: 'clientid',
     client_secret: 'dewier-thrombi-confounder-mikado',
-    api_secret: 'dewier-thrombi-confounder-mikado',
     service_home: 'https://www.servicehome.com',
     postResetUrl: 'https://www.postreset.com',
-    token_endpoint_auth_method: null,
     redirect_uris: [
       'https://www.redirect.com',
     ],
@@ -36,6 +34,8 @@ const mockCurrentServiceInfo = {
     response_types: [
       'code',
     ],
+    api_secret: 'dewier-thrombi-confounder-mikado',
+    token_endpoint_auth_method: null,
   },
 };
 
@@ -43,14 +43,14 @@ const mockCurrentServiceInfo = {
 const mockCurrentServiceModel = {
   name: mockCurrentServiceInfo.name || '',
   description: mockCurrentServiceInfo.description || '',
-  serviceHome: mockCurrentServiceInfo.relyingParty.service_home || '',
-  postResetUrl: mockCurrentServiceInfo.relyingParty.postResetUrl || '',
   clientId: mockCurrentServiceInfo.relyingParty.client_id || '',
   clientSecret: mockCurrentServiceInfo.relyingParty.client_secret || '',
+  serviceHome: mockCurrentServiceInfo.relyingParty.service_home || '',
+  postResetUrl: mockCurrentServiceInfo.relyingParty.postResetUrl || '',
   redirectUris: mockCurrentServiceInfo.relyingParty.redirect_uris || [],
   postLogoutRedirectUris: mockCurrentServiceInfo.relyingParty.post_logout_redirect_uris || [],
-  responseTypes: mockCurrentServiceInfo.relyingParty.response_types || [],
   grantTypes: mockCurrentServiceInfo.relyingParty.grant_types || [],
+  responseTypes: mockCurrentServiceInfo.relyingParty.response_types || [],
   apiSecret: mockCurrentServiceInfo.relyingParty.api_secret || '',
   tokenEndpointAuthMethod: mockCurrentServiceInfo.relyingParty.token_endpoint_auth_method,
 };
@@ -61,10 +61,8 @@ const mockRequestServiceInfo = {
   description: 'service description',
   clientId: 'clientid2',
   clientSecret: 'outshine-wringing-imparting-submitted',
-  apiSecret: 'outshine-wringing-imparting-submitted',
   serviceHome: 'https://www.servicehome2.com',
   postResetUrl: 'https://www.postreset2.com',
-  tokenEndpointAuthMethod: 'client_secret_post',
   redirect_uris: [
     'https://www.redirect.com',
     'https://www.redirect2.com',
@@ -79,6 +77,8 @@ const mockRequestServiceInfo = {
     'code',
     'token',
   ],
+  apiSecret: 'outshine-wringing-imparting-submitted',
+  tokenEndpointAuthMethod: 'client_secret_post',
 };
 
 // Represents the model used for validation and the view.
@@ -533,7 +533,7 @@ describe('when editing the service configuration', () => {
   });
 
   it('then it should return a mix of explicit/expunged elements in the audit editedFields array, if a mix of secret/non-secret fields have been updated', async () => {
-    req.body = getModifiedRequestBody(['name', 'clientSecret', 'clientId', 'apiSecret', 'response_types']);
+    req.body = getModifiedRequestBody(['name', 'clientId', 'clientSecret', 'response_types', 'apiSecret']);
 
     await postServiceConfig(req, res);
     expect(logger.audit.mock.calls).toHaveLength(1);

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -448,6 +448,30 @@ describe('when editing the service configuration', () => {
     expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', []);
   });
 
+  it('then it should treat array fields containing the same values as equal, even if the ordering is different', async () => {
+    const exampleGrantTypes = [
+      'authorization_code',
+      'client_credentials',
+      'implicit',
+      'refresh_token',
+    ];
+
+    // Get a copy of the currentServiceInfo mock data.
+    const databaseServiceInfo = JSON.parse(JSON.stringify(currentServiceInfo));
+    const updatedServiceInfo = getModifiedRequestBody();
+
+    databaseServiceInfo.relyingParty.grant_types = exampleGrantTypes.sort();
+    updatedServiceInfo.grant_types = [...exampleGrantTypes].reverse();
+
+    getServiceById.mockReset();
+    getServiceById.mockReturnValueOnce(databaseServiceInfo);
+    req.body = updatedServiceInfo;
+
+    await postServiceConfig(req, res);
+    expect(logger.audit.mock.calls).toHaveLength(1);
+    expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', []);
+  });
+
   it('then it should return a single element in the audit editedFields array, if only one non-secret primitive field has been updated', async () => {
     req.body = getModifiedRequestBody(['name']);
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -35,7 +35,7 @@ const currentServiceInfo = {
       'code',
     ],
     api_secret: 'dewier-thrombi-confounder-mikado',
-    token_endpoint_auth_method: null,
+    token_endpoint_auth_method: undefined,
   },
 };
 
@@ -52,7 +52,8 @@ const currentServiceModel = {
   grantTypes: currentServiceInfo.relyingParty.grant_types || [],
   responseTypes: currentServiceInfo.relyingParty.response_types || [],
   apiSecret: currentServiceInfo.relyingParty.api_secret || '',
-  tokenEndpointAuthMethod: currentServiceInfo.relyingParty.token_endpoint_auth_method,
+  tokenEndpointAuthMethod: currentServiceInfo.relyingParty.token_endpoint_auth_method === 'client_secret_post'
+    ? 'client_secret_post' : null,
 };
 
 // Represents the request body and the updateService info.

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -9,6 +9,33 @@ const logger = require('./../../../src/infrastructure/logger');
 
 const res = getResponseMock();
 
+const mockCurrentServiceInfo = {
+  id: 'service1',
+  name: 'service one',
+  description: 'service description',
+  relyingParty: {
+    client_id: 'clientid',
+    client_secret: 'dewier-thrombi-confounder-mikado',
+    api_secret: 'dewier-thrombi-confounder-mikado',
+    service_home: 'https://www.servicehome.com',
+    postResetUrl: 'https://www.postreset.com',
+    token_endpoint_auth_method: null,
+    redirect_uris: [
+      'https://www.redirect.com',
+    ],
+    post_logout_redirect_uris: [
+      'https://www.logout.com',
+    ],
+    grant_types: [
+      'implicit',
+      'authorization_code',
+    ],
+    response_types: [
+      'code',
+    ],
+  },
+};
+
 describe('when editing the service configuration', () => {
   let req;
 
@@ -42,31 +69,7 @@ describe('when editing the service configuration', () => {
 
     updateService.mockReset();
     getServiceById.mockReset();
-    getServiceById.mockReturnValueOnce({
-      id: 'service1',
-      name: 'service one',
-      description: 'service description',
-      relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code'
-        ],
-        response_types: [
-          'code',
-        ],
-      },
-    }).mockReturnValueOnce(null);
+    getServiceById.mockReturnValueOnce(mockCurrentServiceInfo).mockReturnValueOnce(null);
     res.mockResetAll();
   });
 
@@ -311,31 +314,7 @@ describe('when editing the service configuration', () => {
 
     // Change mock to return truthy on second call to mimic a service existing with the clientId.
     getServiceById.mockReset();
-    getServiceById.mockReturnValueOnce({
-      id: 'service1',
-      name: 'service one',
-      description: 'service description',
-      relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code',
-        ],
-        response_types: [
-          'code',
-        ],
-      },
-    }).mockReturnValueOnce({
+    getServiceById.mockReturnValueOnce(mockCurrentServiceInfo).mockReturnValueOnce({
       example: true,
     });
 

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -12,7 +12,7 @@ const logger = require('../../../src/infrastructure/logger');
 const res = getResponseMock();
 
 // Represents the getServiceById response.
-const mockCurrentServiceInfo = {
+const currentServiceInfo = {
   id: 'service1',
   name: 'service one',
   description: 'service description',
@@ -40,23 +40,23 @@ const mockCurrentServiceInfo = {
 };
 
 // Represents the current service in the "model" form for validation and comparison.
-const mockCurrentServiceModel = {
-  name: mockCurrentServiceInfo.name || '',
-  description: mockCurrentServiceInfo.description || '',
-  clientId: mockCurrentServiceInfo.relyingParty.client_id || '',
-  clientSecret: mockCurrentServiceInfo.relyingParty.client_secret || '',
-  serviceHome: mockCurrentServiceInfo.relyingParty.service_home || '',
-  postResetUrl: mockCurrentServiceInfo.relyingParty.postResetUrl || '',
-  redirectUris: mockCurrentServiceInfo.relyingParty.redirect_uris || [],
-  postLogoutRedirectUris: mockCurrentServiceInfo.relyingParty.post_logout_redirect_uris || [],
-  grantTypes: mockCurrentServiceInfo.relyingParty.grant_types || [],
-  responseTypes: mockCurrentServiceInfo.relyingParty.response_types || [],
-  apiSecret: mockCurrentServiceInfo.relyingParty.api_secret || '',
-  tokenEndpointAuthMethod: mockCurrentServiceInfo.relyingParty.token_endpoint_auth_method,
+const currentServiceModel = {
+  name: currentServiceInfo.name || '',
+  description: currentServiceInfo.description || '',
+  clientId: currentServiceInfo.relyingParty.client_id || '',
+  clientSecret: currentServiceInfo.relyingParty.client_secret || '',
+  serviceHome: currentServiceInfo.relyingParty.service_home || '',
+  postResetUrl: currentServiceInfo.relyingParty.postResetUrl || '',
+  redirectUris: currentServiceInfo.relyingParty.redirect_uris || [],
+  postLogoutRedirectUris: currentServiceInfo.relyingParty.post_logout_redirect_uris || [],
+  grantTypes: currentServiceInfo.relyingParty.grant_types || [],
+  responseTypes: currentServiceInfo.relyingParty.response_types || [],
+  apiSecret: currentServiceInfo.relyingParty.api_secret || '',
+  tokenEndpointAuthMethod: currentServiceInfo.relyingParty.token_endpoint_auth_method,
 };
 
 // Represents the request body and the updateService info.
-const mockRequestServiceInfo = {
+const requestServiceInfo = {
   name: 'service two',
   description: 'service description',
   clientId: 'clientid2',
@@ -82,31 +82,31 @@ const mockRequestServiceInfo = {
 };
 
 // Represents the model used for validation and the view.
-const mockUpdatedServiceModel = {
-  name: mockRequestServiceInfo.name,
-  description: mockCurrentServiceInfo.description,
-  clientId: mockRequestServiceInfo.clientId,
-  clientSecret: mockRequestServiceInfo.clientSecret,
-  serviceHome: mockRequestServiceInfo.serviceHome,
-  postResetUrl: mockRequestServiceInfo.postResetUrl,
-  redirectUris: mockRequestServiceInfo.redirect_uris,
-  postLogoutRedirectUris: mockRequestServiceInfo.post_logout_redirect_uris,
-  grantTypes: mockRequestServiceInfo.grant_types,
-  responseTypes: mockRequestServiceInfo.response_types,
-  apiSecret: mockRequestServiceInfo.apiSecret,
-  tokenEndpointAuthMethod: mockRequestServiceInfo.tokenEndpointAuthMethod,
+const updatedServiceModel = {
+  name: requestServiceInfo.name,
+  description: currentServiceInfo.description,
+  clientId: requestServiceInfo.clientId,
+  clientSecret: requestServiceInfo.clientSecret,
+  serviceHome: requestServiceInfo.serviceHome,
+  postResetUrl: requestServiceInfo.postResetUrl,
+  redirectUris: requestServiceInfo.redirect_uris,
+  postLogoutRedirectUris: requestServiceInfo.post_logout_redirect_uris,
+  grantTypes: requestServiceInfo.grant_types,
+  responseTypes: requestServiceInfo.response_types,
+  apiSecret: requestServiceInfo.apiSecret,
+  tokenEndpointAuthMethod: requestServiceInfo.tokenEndpointAuthMethod,
 };
 
 /**
- * Creates a version of mockRequestServiceInfo which only modifies the requested fields, the rest remain
- * the same as mockCurrentServiceInfo.
+ * Creates a version of requestServiceInfo which only modifies the requested fields, the rest remain
+ * the same as currentServiceInfo.
  *
- * @param {string[]} fields The fields (matching mockRequestServiceInfo) that need to be modified.
- * @returns A version of mockRequestServiceInfo where only the requested fields are being modified.
+ * @param {string[]} fields The fields (matching requestServiceInfo) that need to be modified.
+ * @returns A version of requestServiceInfo where only the requested fields are being modified.
  */
 const getModifiedRequestBody = (fields = []) => {
   // Throw an error if an invalid/unknown field is requested.
-  const allowedFields = Object.keys(mockRequestServiceInfo);
+  const allowedFields = Object.keys(requestServiceInfo);
   if (fields.length > 1 && !fields.every((field) => allowedFields.includes(field))) {
     throw new Error(`One of the following fields entered are not in mock data: ${fields}`);
   }
@@ -117,10 +117,10 @@ const getModifiedRequestBody = (fields = []) => {
     grant_types: 'grantTypes',
     response_types: 'responseTypes',
   };
-  // Create a version of mockRequestServiceInfo which only alters the requested fields.
+  // Create a version of requestServiceInfo which only alters the requested fields.
   return allowedFields.reduce((request, field) => {
     const modelField = Object.prototype.hasOwnProperty.call(translations, field) ? translations[field] : field;
-    request[field] = fields.includes(field) ? mockUpdatedServiceModel[modelField] : mockCurrentServiceModel[modelField];
+    request[field] = fields.includes(field) ? updatedServiceModel[modelField] : currentServiceModel[modelField];
     return request;
   }, {});
 };
@@ -130,7 +130,7 @@ describe('when editing the service configuration', () => {
 
   beforeEach(() => {
     req = getRequestMock({
-      body: { ...mockRequestServiceInfo },
+      body: { ...requestServiceInfo },
       params: {
         sid: 'service1',
       },
@@ -138,7 +138,7 @@ describe('when editing the service configuration', () => {
 
     updateService.mockReset();
     getServiceById.mockReset();
-    getServiceById.mockReturnValueOnce({ ...mockCurrentServiceInfo }).mockReturnValueOnce(null);
+    getServiceById.mockReturnValueOnce({ ...currentServiceInfo }).mockReturnValueOnce(null);
     res.mockResetAll();
   });
 
@@ -153,7 +153,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         name: req.body.name,
       },
       serviceId: 'service1',
@@ -175,7 +175,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         serviceHome: req.body.serviceHome,
       },
       serviceId: 'service1',
@@ -197,7 +197,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -220,7 +220,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -243,7 +243,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -264,7 +264,7 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls[0][0]).toBe('service1');
 
     expect(updateService.mock.calls[0][1]).toEqual({
-      ...mockRequestServiceInfo,
+      ...requestServiceInfo,
       clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
@@ -276,7 +276,7 @@ describe('when editing the service configuration', () => {
 
     // Change mock to return truthy on second call to mimic a service existing with the clientId.
     getServiceById.mockReset();
-    getServiceById.mockReturnValueOnce(mockCurrentServiceInfo).mockReturnValueOnce({
+    getServiceById.mockReturnValueOnce(currentServiceInfo).mockReturnValueOnce({
       example: true,
     });
 
@@ -290,7 +290,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -310,7 +310,7 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
     expect(updateService.mock.calls[0][1]).toEqual({
-      ...mockRequestServiceInfo,
+      ...requestServiceInfo,
       clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
@@ -325,7 +325,7 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
     expect(updateService.mock.calls[0][1]).toEqual({
-      ...mockRequestServiceInfo,
+      ...requestServiceInfo,
       clientId: req.body.clientId,
     });
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
@@ -345,7 +345,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         redirectUris: req.body.redirect_uris,
       },
       serviceId: 'service1',
@@ -369,7 +369,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
         tokenEndpointAuthMethod: req.body.tokenEndpointAuthMethod,
       },
@@ -395,7 +395,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockUpdatedServiceModel,
+        ...updatedServiceModel,
         clientId: req.body.clientId,
         tokenEndpointAuthMethod: null,
       },
@@ -413,7 +413,7 @@ describe('when editing the service configuration', () => {
     expect(updateService.mock.calls).toHaveLength(1);
     expect(updateService.mock.calls[0][0]).toBe('service1');
 
-    expect(updateService.mock.calls[0][1]).toEqual(mockRequestServiceInfo);
+    expect(updateService.mock.calls[0][1]).toEqual(requestServiceInfo);
     expect(updateService.mock.calls[0][2]).toBe('correlationId');
   });
 
@@ -428,12 +428,12 @@ describe('when editing the service configuration', () => {
       userId: 'user1',
       userEmail: 'user@unit.test',
       editedService: 'service1',
-      editedFields: Object.keys(mockCurrentServiceModel).filter((key) => key !== 'description').map((key) => {
+      editedFields: Object.keys(currentServiceModel).filter((key) => key !== 'description').map((key) => {
         const isSecret = key.toLowerCase().includes('secret');
         return {
           name: key,
-          oldValue: isSecret ? 'EXPUNGED' : mockCurrentServiceModel[key],
-          newValue: isSecret ? 'EXPUNGED' : mockUpdatedServiceModel[key],
+          oldValue: isSecret ? 'EXPUNGED' : currentServiceModel[key],
+          newValue: isSecret ? 'EXPUNGED' : updatedServiceModel[key],
         };
       }),
     });
@@ -455,7 +455,7 @@ describe('when editing the service configuration', () => {
     expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', [
       {
         name: 'name',
-        oldValue: mockCurrentServiceModel.name,
+        oldValue: currentServiceModel.name,
         newValue: req.body.name,
       },
     ]);
@@ -469,7 +469,7 @@ describe('when editing the service configuration', () => {
     expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', [
       {
         name: 'grantTypes',
-        oldValue: mockCurrentServiceModel.grantTypes,
+        oldValue: currentServiceModel.grantTypes,
         newValue: req.body.grant_types,
       },
     ]);
@@ -497,17 +497,17 @@ describe('when editing the service configuration', () => {
     expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', [
       {
         name: 'name',
-        oldValue: mockCurrentServiceModel.name,
+        oldValue: currentServiceModel.name,
         newValue: req.body.name,
       },
       {
         name: 'clientId',
-        oldValue: mockCurrentServiceModel.clientId,
+        oldValue: currentServiceModel.clientId,
         newValue: req.body.clientId,
       },
       {
         name: 'responseTypes',
-        oldValue: mockCurrentServiceModel.responseTypes,
+        oldValue: currentServiceModel.responseTypes,
         newValue: req.body.response_types,
       },
     ]);
@@ -540,12 +540,12 @@ describe('when editing the service configuration', () => {
     expect(logger.audit.mock.calls[0][1]).toHaveProperty('editedFields', [
       {
         name: 'name',
-        oldValue: mockCurrentServiceModel.name,
+        oldValue: currentServiceModel.name,
         newValue: req.body.name,
       },
       {
         name: 'clientId',
-        oldValue: mockCurrentServiceModel.clientId,
+        oldValue: currentServiceModel.clientId,
         newValue: req.body.clientId,
       },
       {
@@ -555,7 +555,7 @@ describe('when editing the service configuration', () => {
       },
       {
         name: 'responseTypes',
-        oldValue: mockCurrentServiceModel.responseTypes,
+        oldValue: currentServiceModel.responseTypes,
         newValue: req.body.response_types,
       },
       {

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -1,11 +1,13 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
+const mockUtils = require('../../utils');
+
+jest.mock('./../../../src/infrastructure/config', () => mockUtils.configMockFactory());
+jest.mock('./../../../src/infrastructure/logger', () => mockUtils.loggerMockFactory());
 jest.mock('./../../../src/infrastructure/applications');
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const postServiceConfig = require('./../../../src/app/services/serviceConfig').postServiceConfig;
-const { getServiceById, updateService } = require('./../../../src/infrastructure/applications');
-const logger = require('./../../../src/infrastructure/logger');
+const { getRequestMock, getResponseMock } = require('../../utils');
+const { postServiceConfig } = require('../../../src/app/services/serviceConfig');
+const { getServiceById, updateService } = require('../../../src/infrastructure/applications');
+const logger = require('../../../src/infrastructure/logger');
 
 const res = getResponseMock();
 
@@ -89,18 +91,18 @@ describe('when editing the service configuration', () => {
         clientSecret: 'outshine-wringing-imparting-submitted',
         description: 'service description',
         grantTypes: [
-          'implicit'
+          'implicit',
         ],
         postLogoutRedirectUris: [
-          'https://www.logout2.com'
+          'https://www.logout2.com',
         ],
         postResetUrl: 'https://www.postreset2.com',
         redirectUris: [
           'https://www.redirect.com',
-          'https://www.redirect2.com'
+          'https://www.redirect2.com',
         ],
         responseTypes: [
-          'code'
+          'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
         tokenEndpointAuthMethod: null,
@@ -129,18 +131,18 @@ describe('when editing the service configuration', () => {
         clientSecret: 'outshine-wringing-imparting-submitted',
         description: 'service description',
         grantTypes: [
-          'implicit'
+          'implicit',
         ],
         postLogoutRedirectUris: [
-          'https://www.logout2.com'
+          'https://www.logout2.com',
         ],
         postResetUrl: 'https://www.postreset2.com',
         redirectUris: [
           'https://www.redirect.com',
-          'https://www.redirect2.com'
+          'https://www.redirect2.com',
         ],
         responseTypes: [
-          'code'
+          'code',
         ],
         serviceHome: 'not-a-url',
         tokenEndpointAuthMethod: null,
@@ -169,18 +171,18 @@ describe('when editing the service configuration', () => {
         clientSecret: 'outshine-wringing-imparting-submitted',
         description: 'service description',
         grantTypes: [
-          'implicit'
+          'implicit',
         ],
         postLogoutRedirectUris: [
-          'https://www.logout2.com'
+          'https://www.logout2.com',
         ],
         postResetUrl: 'https://www.postreset2.com',
         redirectUris: [
           'https://www.redirect.com',
-          'https://www.redirect2.com'
+          'https://www.redirect2.com',
         ],
         responseTypes: [
-          'code'
+          'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
         tokenEndpointAuthMethod: null,
@@ -425,7 +427,7 @@ describe('when editing the service configuration', () => {
   });
 
   it('then it should render view with validation if redirect urls are not unique', async () => {
-    req.body.redirect_uris =  [
+    req.body.redirect_uris = [
       'https://www.redirect.com',
       'https://www.redirect.com',
     ];
@@ -443,18 +445,18 @@ describe('when editing the service configuration', () => {
         clientSecret: 'outshine-wringing-imparting-submitted',
         description: 'service description',
         grantTypes: [
-          'implicit'
+          'implicit',
         ],
         postLogoutRedirectUris: [
-          'https://www.logout2.com'
+          'https://www.logout2.com',
         ],
         postResetUrl: 'https://www.postreset2.com',
         redirectUris: [
           'https://www.redirect.com',
-          'https://www.redirect.com'
+          'https://www.redirect.com',
         ],
         responseTypes: [
-          'code'
+          'code',
         ],
         serviceHome: 'https://www.servicehome2.com',
         tokenEndpointAuthMethod: null,
@@ -596,5 +598,4 @@ describe('when editing the service configuration', () => {
       editedService: 'service1',
     });
   });
-
 });

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -35,36 +35,37 @@ const mockCurrentServiceInfo = {
     ],
   },
 };
+const mockUpdatedServiceInfo = {
+  name: 'service two',
+  description: 'service description',
+  clientId: 'clientid2',
+  clientSecret: 'outshine-wringing-imparting-submitted',
+  serviceHome: 'https://www.servicehome2.com',
+  postResetUrl: 'https://www.postreset2.com',
+  redirect_uris: [
+    'https://www.redirect.com',
+    'https://www.redirect2.com',
+  ],
+  post_logout_redirect_uris: [
+    'https://www.logout2.com',
+  ],
+  grant_types: [
+    'implicit',
+  ],
+  response_types: [
+    'code',
+  ],
+};
 
 describe('when editing the service configuration', () => {
   let req;
 
   beforeEach(() => {
     req = getRequestMock({
-      body: {
-        name: 'service two',
-        description: 'service description',
-        clientId: 'clientid2',
-        clientSecret: 'outshine-wringing-imparting-submitted',
-        serviceHome: 'https://www.servicehome2.com',
-        postResetUrl: 'https://www.postreset2.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-          'https://www.redirect2.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout2.com',
-        ],
-        grant_types: [
-          'implicit',
-        ],
-        response_types: [
-          'code',
-        ],
-      },
+      body: { ...mockUpdatedServiceInfo },
       params: {
         sid: 'service1',
-      }
+      },
     });
 
     updateService.mockReset();

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -65,7 +65,7 @@ const mockRequestServiceInfo = {
 };
 
 // Represents the model used for validation and the view.
-const mockModelServiceInfo = {
+const mockUpdatedServiceModel = {
   name: mockRequestServiceInfo.name,
   description: mockCurrentServiceInfo.description,
   clientId: mockRequestServiceInfo.clientId,
@@ -108,7 +108,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         name: req.body.name,
       },
       serviceId: 'service1',
@@ -130,7 +130,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         serviceHome: req.body.serviceHome,
       },
       serviceId: 'service1',
@@ -152,7 +152,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -175,7 +175,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -198,7 +198,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -245,7 +245,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
       },
       serviceId: 'service1',
@@ -300,7 +300,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         redirectUris: req.body.redirect_uris,
       },
       serviceId: 'service1',
@@ -324,7 +324,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
         tokenEndpointAuthMethod: req.body.tokenEndpointAuthMethod,
       },
@@ -350,7 +350,7 @@ describe('when editing the service configuration', () => {
       csrfToken: 'token',
       currentNavigation: 'configuration',
       service: {
-        ...mockModelServiceInfo,
+        ...mockUpdatedServiceModel,
         clientId: req.body.clientId,
         tokenEndpointAuthMethod: null,
       },


### PR DESCRIPTION
Implementation and tests for: https://dfe-secureaccess.atlassian.net/browse/NSA-6469

Changes:

- Added an editedFields property to the audit log meta when a service config is edited.
- Any secret fields (name contains "secret") values are logged as "EXPUNGED".
- postServiceConfig tests have been made more parameterised.
- Multiple ESLint fixes.