### PR TITLE
[DSI-6826]remove sensitive logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
         "login.dfe.notifications.client": "git+https://github.com/DFE-Digital/login.dfe.notifications.client.git#v5.2.0",
         "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+        "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.1.0",
         "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
         "login.dfe.service-notifications.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.client.git#v2.0.0",
         "login.dfe.validation": "git+https://github.com/DFE-Digital/login.dfe.validation.git#v2.0.15",
@@ -8432,8 +8432,8 @@
       }
     },
     "node_modules/login.dfe.request-promise-retry": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#cedf7a91a4c7e1d51f51389c4ff3c2aa4273aa1d",
+      "version": "3.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#c6cb2494c9dce08cc41bdcbe3d999059c3a13237",
       "license": "MIT",
       "dependencies": {
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ioredis": "^5.3.2",
         "lodash": "^4.17.21",
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",
-        "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.1.0",
+        "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.1",
         "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.3",
         "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
         "login.dfe.express-flash-2": "git+https://github.com/DFE-Digital/login.dfe.express-flash-2.git#v2.0.0",
@@ -8338,8 +8338,8 @@
       }
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport": {
-      "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#42dd70d6b310c7916ab14c00517f962f5ed32904",
+      "version": "3.2.1",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#6aab608ca61dcd5607d77e3a8e48301dfac75d2f",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ioredis": "^5.3.2",
     "lodash": "^4.17.21",
     "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",
-    "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.1.0",
+    "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.1",
     "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.3",
     "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
     "login.dfe.express-flash-2": "git+https://github.com/DFE-Digital/login.dfe.express-flash-2.git#v2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
     "login.dfe.notifications.client": "git+https://github.com/DFE-Digital/login.dfe.notifications.client.git#v5.2.0",
     "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+    "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.1.0",
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
     "login.dfe.service-notifications.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.client.git#v2.0.0",
     "login.dfe.validation": "git+https://github.com/DFE-Digital/login.dfe.validation.git#v2.0.15",


### PR DESCRIPTION
**Parent Ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-6725
**Ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-6826

**Changes:**

Updated login.dfe.request-promise-retry package version to not log every request body.
Updated login.dfe.audit.winston-sequelize-transport to refrain from logging the SQL statements that are not utilised
Updated logger to only send audit records containing the email address to the Audit DB, and not to the console/app insights.