### PR TITLE
[NSA-8063] Policy role names and conditions sorting

### DIFF
--- a/src/app/services/utils.js
+++ b/src/app/services/utils.js
@@ -51,7 +51,7 @@ const getUserDetailsById = async (uid, correlationId) => {
   const ktsDetails = serviceDetails ? serviceDetails.find((c) => c.serviceId.toLowerCase() === config.serviceMapping.key2SuccessServiceId.toLowerCase()) : undefined;
   let externalIdentifier = "";
   if (ktsDetails && ktsDetails.identifiers) {
-    const key = ktsDetails.identifiers.find((a) => (a.key = "k2s-id"));
+    const key = ktsDetails.identifiers.find((a) => a.key === "k2s-id");
     if (key) {
       externalIdentifier = key.value;
     }
@@ -239,15 +239,21 @@ const getFriendlyOrganisationType = async (typeId) => {
 
 const getFriendlyFieldName = (fieldName) => {
   const conversions = [
-    { source: "id", friendly: "user" },
-    { source: "organisation.category.id", friendly: "category" },
-    { source: "organisation.id", friendly: "organisation" },
-    { source: "organisation.localAuthority.id", friendly: "local authority" },
-    { source: "organisation.phaseOfEducation.id", friendly: "phase of education" },
-    { source: "organisation.region.id", friendly: "region" },
-    { source: "organisation.status.id", friendly: "status" },
-    { source: "organisation.type.id", friendly: "type" },
-    { source: "role.id", friendly: "role" },
+    { source: "email", friendly: "User email" },
+    { source: "id", friendly: "User" },
+    { source: "organisation.category.id", friendly: "Organisation category" },
+    { source: "organisation.id", friendly: "Organisation" },
+    { source: "organisation.IsOnAPAR", friendly: "Organisation on APAR" },
+    { source: "organisation.localAuthority.id", friendly: "Organisation Local Authority number" },
+    { source: "organisation.name", friendly: "Organisation name" },
+    { source: "organisation.phaseOfEducation.id", friendly: "Organisation phase of education" },
+    { source: "organisation.region.id", friendly: "Organisation region" },
+    { source: "organisation.status.id", friendly: "Organisation status" },
+    { source: "organisation.type.id", friendly: "Organisation type" },
+    { source: "organisation.ukprn", friendly: "Organisation UKPRN" },
+    { source: "organisation.urn", friendly: "Organisation URN" },
+    { source: "role.id", friendly: "User role ID" },
+    { source: "role.name", friendly: "User role name" },
   ];
 
   const conversion = conversions.find((x) => x.source === fieldName);

--- a/src/utils/asyncHelpers.js
+++ b/src/utils/asyncHelpers.js
@@ -1,21 +1,38 @@
-const mapAsync = async (col, iteratee) => {
+const mapAsync = async (col, iteratee, chunkSize = 50) => {
   if (col.length === undefined) {
-    throw new Error('col is not iterable');
+    throw new Error("col is not iterable");
+  }
+
+  if (chunkSize <= 0) {
+    throw new Error("chunk size must be > 0");
+  }
+
+  const temp = [...col];
+  const chunks = [];
+  while (temp.length) {
+    chunks.push(temp.splice(0, chunkSize));
   }
 
   const result = [];
-  for (let i = 0; i < col.length; i += 1) {
-    result[i] = await iteratee(col[i], i);
+
+  for (let chunk = 0; chunk < chunks.length; chunk += 1) {
+    // Await in loop required to chunk up requests to avoid overloading our APIs.
+    // eslint-disable-next-line no-await-in-loop
+    const chunkResult = await Promise.all(chunks[chunk].map((value, index) => iteratee(value, chunk * chunkSize + index)));
+    result.push(...chunkResult);
   }
+
   return result;
 };
 
 const forEachAsync = async (col, iteratee) => {
   if (col.length === undefined) {
-    throw new Error('col is not iterable');
+    throw new Error("col is not iterable");
   }
 
   for (let i = 0; i < col.length; i += 1) {
+    // We want this to run in order, so await in for is needed.
+    // eslint-disable-next-line no-await-in-loop
     await iteratee(col[i], i);
   }
 };

--- a/test/app/services/getPolicyConditionsAndRoles.test.js
+++ b/test/app/services/getPolicyConditionsAndRoles.test.js
@@ -1,14 +1,14 @@
 /* eslint-disable global-require */
-jest.mock('../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
+jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
 /* eslint-enable global-require */
-jest.mock('../../../src/infrastructure/applications');
-jest.mock('../../../src/infrastructure/access');
+jest.mock("../../../src/infrastructure/applications");
+jest.mock("../../../src/infrastructure/access");
 
-const { getRequestMock, getResponseMock } = require('../../utils');
-const getPolicyConditions = require('../../../src/app/services/getPolicyConditionsAndRoles');
-const { getServiceById } = require('../../../src/infrastructure/applications');
-const { getPolicyById } = require('../../../src/infrastructure/access');
+const { getRequestMock, getResponseMock } = require("../../utils");
+const getPolicyConditions = require("../../../src/app/services/getPolicyConditionsAndRoles");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const { getPolicyById } = require("../../../src/infrastructure/access");
 
 const res = getResponseMock();
 
@@ -18,152 +18,154 @@ describe("When displaying the selected policy's conditions and roles", () => {
   beforeEach(() => {
     req = getRequestMock({
       params: {
-        sid: 'service1',
-        pid: 'policy1',
+        sid: "service1",
+        pid: "policy1",
       },
       userServices: {
-        roles: [{
-          code: 'serviceid_serviceconfiguration',
-        }],
+        roles: [
+          {
+            code: "serviceid_serviceconfiguration",
+          },
+        ],
       },
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     getPolicyById.mockReset();
     getPolicyById.mockReturnValue({
-      applicationId: 'service1',
+      applicationId: "service1",
       conditions: [
         {
-          field: 'organisation.type.id',
-          operator: 'is',
-          value: ['46'],
+          field: "organisation.type.id",
+          operator: "is",
+          value: ["46"],
         },
       ],
       roles: [
         {
-          id: 'test',
-          name: 'Test Role',
-          code: 'testRole',
+          id: "test",
+          name: "Test Role",
+          code: "testRole",
         },
       ],
-      id: 'conditionId',
-      name: 'condition name',
+      id: "conditionId",
+      name: "condition name",
     });
   });
 
-  it('then it should return the policy conditions view', async () => {
+  it("then it should return the policy conditions view", async () => {
     await getPolicyConditions(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/policyConditionsAndRoles');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/policyConditionsAndRoles");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getPolicyConditions(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should get the service by id', async () => {
+  it("then it should get the service by id", async () => {
     await getPolicyConditions(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(1);
-    expect(getServiceById.mock.calls[0][0]).toBe('service1');
-    expect(getServiceById.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceById.mock.calls[0][0]).toBe("service1");
+    expect(getServiceById.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the policy by id', async () => {
+  it("then it should get the policy by id", async () => {
     await getPolicyConditions(req, res);
 
     expect(getPolicyById.mock.calls).toHaveLength(1);
-    expect(getPolicyById.mock.calls[0][0]).toBe('service1');
-    expect(getPolicyById.mock.calls[0][1]).toBe('policy1');
-    expect(getPolicyById.mock.calls[0][2]).toBe('correlationId');
+    expect(getPolicyById.mock.calls[0][0]).toBe("service1");
+    expect(getPolicyById.mock.calls[0][1]).toBe("policy1");
+    expect(getPolicyById.mock.calls[0][2]).toBe("correlationId");
   });
 
-  it('then it should include the mapped policy ', async () => {
+  it("then it should include the mapped policy ", async () => {
     await getPolicyConditions(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       policy: {
-        applicationId: 'service1',
+        applicationId: "service1",
         conditions: [
           {
-            field: 'type',
-            operator: 'is',
-            value: ['Academy 16-19 Sponsor Led'],
+            field: "Organisation type",
+            operator: "is",
+            value: ["Academy 16-19 Sponsor Led"],
           },
         ],
       },
     });
   });
 
-  it('then it should return the roles in the policy sorted by name', async () => {
+  it("then it should return the roles in the policy sorted by name", async () => {
     getPolicyById.mockReturnValue({
-      id: 'conditionId',
-      name: 'condition name',
-      applicationId: 'service1',
+      id: "conditionId",
+      name: "condition name",
+      applicationId: "service1",
       conditions: [],
       roles: [
         {
-          id: 'test',
-          name: 'Role C',
-          code: 'testRole1',
+          id: "test",
+          name: "Role C",
+          code: "testRole1",
         },
         {
-          id: 'test',
-          name: 'Role A',
-          code: 'testRole2',
+          id: "test",
+          name: "Role A",
+          code: "testRole2",
         },
         {
-          id: 'test',
-          name: 'Role E',
-          code: 'testRole3',
+          id: "test",
+          name: "Role E",
+          code: "testRole3",
         },
         {
-          id: 'test',
-          name: 'Role B',
-          code: 'testRole4',
+          id: "test",
+          name: "Role B",
+          code: "testRole4",
         },
       ],
     });
 
     await getPolicyConditions(req, res);
-    expect(res.render.mock.calls[0][1].policy.roles[0].name).toBe('Role A');
-    expect(res.render.mock.calls[0][1].policy.roles[1].name).toBe('Role B');
-    expect(res.render.mock.calls[0][1].policy.roles[2].name).toBe('Role C');
-    expect(res.render.mock.calls[0][1].policy.roles[3].name).toBe('Role E');
+    expect(res.render.mock.calls[0][1].policy.roles[0].name).toBe("Role A");
+    expect(res.render.mock.calls[0][1].policy.roles[1].name).toBe("Role B");
+    expect(res.render.mock.calls[0][1].policy.roles[2].name).toBe("Role C");
+    expect(res.render.mock.calls[0][1].policy.roles[3].name).toBe("Role E");
   });
 
-  it('then it should return the condition fields in the policy sorted by name', async () => {
+  it("then it should return the condition fields in the policy sorted by name", async () => {
     getPolicyById.mockReturnValue({
-      id: 'conditionId',
-      name: 'condition name',
-      applicationId: 'service1',
+      id: "conditionId",
+      name: "condition name",
+      applicationId: "service1",
       conditions: [
         {
-          field: 'Condition B',
+          field: "Condition B",
           value: [],
         },
         {
-          field: 'Condition D',
+          field: "Condition D",
           value: [],
         },
         {
-          field: 'Condition C',
+          field: "Condition C",
           value: [],
         },
         {
-          field: 'Condition A',
+          field: "Condition A",
           value: [],
         },
       ],
@@ -171,21 +173,21 @@ describe("When displaying the selected policy's conditions and roles", () => {
     });
 
     await getPolicyConditions(req, res);
-    expect(res.render.mock.calls[0][1].policy.conditions[0].field).toBe('Condition A');
-    expect(res.render.mock.calls[0][1].policy.conditions[1].field).toBe('Condition B');
-    expect(res.render.mock.calls[0][1].policy.conditions[2].field).toBe('Condition C');
-    expect(res.render.mock.calls[0][1].policy.conditions[3].field).toBe('Condition D');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].field).toBe("Condition A");
+    expect(res.render.mock.calls[0][1].policy.conditions[1].field).toBe("Condition B");
+    expect(res.render.mock.calls[0][1].policy.conditions[2].field).toBe("Condition C");
+    expect(res.render.mock.calls[0][1].policy.conditions[3].field).toBe("Condition D");
   });
 
-  it('then it should return the values for a numeric condition sorted numerically', async () => {
+  it("then it should return the values for a numeric condition sorted numerically", async () => {
     getPolicyById.mockReturnValue({
-      id: 'conditionId',
-      name: 'condition name',
-      applicationId: 'service1',
+      id: "conditionId",
+      name: "condition name",
+      applicationId: "service1",
       conditions: [
         {
-          field: 'Condition A',
-          value: ['01', '2', '1', '02', '010', '0.1'],
+          field: "Condition A",
+          value: ["01", "2", "1", "02", "010", "0.1"],
         },
       ],
       roles: [],
@@ -193,35 +195,34 @@ describe("When displaying the selected policy's conditions and roles", () => {
 
     await getPolicyConditions(req, res);
     // Will sort the values parsed as numbers, so 02 === 2, and 010 === 10.
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe('0.1');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe('01');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe('1');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe('2');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe('02');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe('010');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe("0.1");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe("01");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe("1");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe("2");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe("02");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe("010");
   });
 
-  it('then it should return the values for an alphanumeric condition values sorted lexicographically', async () => {
+  it("then it should return the values for an alphanumeric condition values sorted lexicographically", async () => {
     getPolicyById.mockReturnValue({
-      id: 'conditionId',
-      name: 'condition name',
-      applicationId: 'service1',
+      id: "conditionId",
+      name: "condition name",
+      applicationId: "service1",
       conditions: [
         {
-          field: 'Condition A',
-          value: ['D', 'A', 'E', 'Z', 'B', 'D'],
+          field: "Condition A",
+          value: ["D", "A", "E", "Z", "B", "D"],
         },
       ],
       roles: [],
     });
 
     await getPolicyConditions(req, res);
-    // Will sort the values parsed as integers, so 02 === 2, and 010 === 10.
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe('A');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe('B');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe('D');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe('D');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe('E');
-    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe('Z');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe("A");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe("B");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe("D");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe("D");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe("E");
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe("Z");
   });
 });

--- a/test/app/services/getPolicyConditionsAndRoles.test.js
+++ b/test/app/services/getPolicyConditionsAndRoles.test.js
@@ -1,7 +1,9 @@
-jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/access');
+/* eslint-disable global-require */
+jest.mock('../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
+jest.mock('../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
+/* eslint-enable global-require */
+jest.mock('../../../src/infrastructure/applications');
+jest.mock('../../../src/infrastructure/access');
 
 const { getRequestMock, getResponseMock } = require('../../utils');
 const getPolicyConditions = require('../../../src/app/services/getPolicyConditionsAndRoles');
@@ -10,7 +12,7 @@ const { getPolicyById } = require('../../../src/infrastructure/access');
 
 const res = getResponseMock();
 
-describe('when displaying the confirm edit service view', () => {
+describe("When displaying the selected policy's conditions and roles", () => {
   let req;
 
   beforeEach(() => {
@@ -41,9 +43,14 @@ describe('when displaying the confirm edit service view', () => {
         {
           field: 'organisation.type.id',
           operator: 'is',
-          value: [
-            '46',
-          ],
+          value: ['46'],
+        },
+      ],
+      roles: [
+        {
+          id: 'test',
+          name: 'Test Role',
+          code: 'testRole',
         },
       ],
       id: 'conditionId',
@@ -93,13 +100,128 @@ describe('when displaying the confirm edit service view', () => {
           {
             field: 'type',
             operator: 'is',
-            value: [
-              'Academy 16-19 Sponsor Led',
-            ],
+            value: ['Academy 16-19 Sponsor Led'],
           },
         ],
-
       },
     });
+  });
+
+  it('then it should return the roles in the policy sorted by name', async () => {
+    getPolicyById.mockReturnValue({
+      id: 'conditionId',
+      name: 'condition name',
+      applicationId: 'service1',
+      conditions: [],
+      roles: [
+        {
+          id: 'test',
+          name: 'Role C',
+          code: 'testRole1',
+        },
+        {
+          id: 'test',
+          name: 'Role A',
+          code: 'testRole2',
+        },
+        {
+          id: 'test',
+          name: 'Role E',
+          code: 'testRole3',
+        },
+        {
+          id: 'test',
+          name: 'Role B',
+          code: 'testRole4',
+        },
+      ],
+    });
+
+    await getPolicyConditions(req, res);
+    expect(res.render.mock.calls[0][1].policy.roles[0].name).toBe('Role A');
+    expect(res.render.mock.calls[0][1].policy.roles[1].name).toBe('Role B');
+    expect(res.render.mock.calls[0][1].policy.roles[2].name).toBe('Role C');
+    expect(res.render.mock.calls[0][1].policy.roles[3].name).toBe('Role E');
+  });
+
+  it('then it should return the condition fields in the policy sorted by name', async () => {
+    getPolicyById.mockReturnValue({
+      id: 'conditionId',
+      name: 'condition name',
+      applicationId: 'service1',
+      conditions: [
+        {
+          field: 'Condition B',
+          value: [],
+        },
+        {
+          field: 'Condition D',
+          value: [],
+        },
+        {
+          field: 'Condition C',
+          value: [],
+        },
+        {
+          field: 'Condition A',
+          value: [],
+        },
+      ],
+      roles: [],
+    });
+
+    await getPolicyConditions(req, res);
+    expect(res.render.mock.calls[0][1].policy.conditions[0].field).toBe('Condition A');
+    expect(res.render.mock.calls[0][1].policy.conditions[1].field).toBe('Condition B');
+    expect(res.render.mock.calls[0][1].policy.conditions[2].field).toBe('Condition C');
+    expect(res.render.mock.calls[0][1].policy.conditions[3].field).toBe('Condition D');
+  });
+
+  it('then it should return the values for a numeric condition sorted numerically', async () => {
+    getPolicyById.mockReturnValue({
+      id: 'conditionId',
+      name: 'condition name',
+      applicationId: 'service1',
+      conditions: [
+        {
+          field: 'Condition A',
+          value: ['01', '2', '1', '02', '010', '0.1'],
+        },
+      ],
+      roles: [],
+    });
+
+    await getPolicyConditions(req, res);
+    // Will sort the values parsed as numbers, so 02 === 2, and 010 === 10.
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe('0.1');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe('01');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe('1');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe('2');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe('02');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe('010');
+  });
+
+  it('then it should return the values for an alphanumeric condition values sorted lexicographically', async () => {
+    getPolicyById.mockReturnValue({
+      id: 'conditionId',
+      name: 'condition name',
+      applicationId: 'service1',
+      conditions: [
+        {
+          field: 'Condition A',
+          value: ['D', 'A', 'E', 'Z', 'B', 'D'],
+        },
+      ],
+      roles: [],
+    });
+
+    await getPolicyConditions(req, res);
+    // Will sort the values parsed as integers, so 02 === 2, and 010 === 10.
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[0]).toBe('A');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[1]).toBe('B');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[2]).toBe('D');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[3]).toBe('D');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[4]).toBe('E');
+    expect(res.render.mock.calls[0][1].policy.conditions[0].value[5]).toBe('Z');
   });
 });


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8063

Note: Deployed in DEV before rebase to squash ESLint fix commits, and no issues found with developer testing.

## Changes
- Implements sorting for policy roles, condition fields, and condition values:
  - Policy roles and condition fields are sorted alphabetically.
  - Policy condition values will either sort numerically if they contain only digits, or alphabetically if they are alphanumeric.
- Implemented concurrency to the mapAsync function, currently set to 50 requests at a time, to reduce the load time of larger policies.
- Added additional "friendly" names for the policy condition fields we have currently across the environments, approved by the UCD team.

## Benchmarks

These benchmarks involved taking an average of 10 requests with the browser cache disabled, on our largest and smallest policy that was accessible in each environment:

- Local:
  - Largest Before: 16.213s
  - Largest After: 2.95s
  - Smallest Before: 0.865s
  - Smallest After: 0.755s
- Dev:
  - Largest Before: 7.946s
  - Largest After: 1.852s
  - Smallest Before: 0.709s
  - Smallest After: 0.568s