### PR TITLE
[NSA-8144] Fix navigation bugs when going to user pages from an organisation.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,6 @@
     "jest": true
   },
   "parserOptions": {
-    "ecmaVersion": 2019
+    "ecmaVersion": 2023
   }
 }

--- a/src/app/services/associateService.js
+++ b/src/app/services/associateService.js
@@ -1,7 +1,7 @@
 const PolicyEngine = require("login.dfe.policy-engine");
 const config = require("../../infrastructure/config");
 const { getServiceById } = require("../../infrastructure/applications");
-const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getUserDetails, getUserServiceRoles, getReturnUrl } = require("./utils");
 const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 
 const policyEngine = new PolicyEngine(config);
@@ -14,19 +14,13 @@ const getViewModel = async (req) => {
   const serviceRoles = policyResult.rolesAvailableToUser;
   const manageRolesForService = await getUserServiceRoles(req);
 
-  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return {
     csrfToken: req.csrfToken(),
     service,
     serviceRoles,
     selectedRoles: [],
     user,
-    backLink,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`),
     organisation,
     validationMessages: {},
     serviceId: req.params.sid,
@@ -63,8 +57,7 @@ const post = async (req, res) => {
     roles: selectedRoles,
   };
 
-  const returnOrgId = getReturnOrgId(req.query);
-  return res.redirect(`confirm-associate-service${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+  return res.redirect(getReturnUrl(req.query, "confirm-associate-service"));
 };
 
 module.exports = {

--- a/src/app/services/associateService.js
+++ b/src/app/services/associateService.js
@@ -1,8 +1,8 @@
-const PolicyEngine = require('login.dfe.policy-engine');
-const config = require('../../infrastructure/config');
-const { getServiceById } = require('../../infrastructure/applications');
-const { getUserDetails, getUserServiceRoles } = require('./utils');
-const { getOrganisationByIdV2 } = require('../../infrastructure/organisations');
+const PolicyEngine = require("login.dfe.policy-engine");
+const config = require("../../infrastructure/config");
+const { getServiceById } = require("../../infrastructure/applications");
+const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 
 const policyEngine = new PolicyEngine(config);
 
@@ -10,37 +10,34 @@ const getViewModel = async (req) => {
   const user = await getUserDetails(req);
   const organisation = await getOrganisationByIdV2(req.params.oid, req.id);
   const service = await getServiceById(req.params.sid);
-  const policyResult = await policyEngine.getPolicyApplicationResultsForUser(req.params.uid.startsWith('inv-') ? undefined : req.params.uid, req.params.oid, req.params.sid, req.id);
+  const policyResult = await policyEngine.getPolicyApplicationResultsForUser(req.params.uid.startsWith("inv-") ? undefined : req.params.uid, req.params.oid, req.params.sid, req.id);
   const serviceRoles = policyResult.rolesAvailableToUser;
   const manageRolesForService = await getUserServiceRoles(req);
-  let links = '';
 
-  if(req.params.currentIod === undefined){
-    links = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  }else{
-    links = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.currentIod}/userDetails`;
+  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink += `?returnOrg=${returnOrgId}`;
   }
 
   return {
     csrfToken: req.csrfToken(),
-    cancelLink: links,
     service,
     serviceRoles,
     selectedRoles: [],
     user,
-    backLink: links,
+    backLink,
     organisation,
     validationMessages: {},
     serviceId: req.params.sid,
-    organisationId: req.params.currentIod,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
+    currentNavigation: "users",
   };
 };
 
 const get = async (req, res) => {
   const model = await getViewModel(req);
-  return res.render('services/views/associateService', model);
+  return res.render("services/views/associateService", model);
 };
 
 const post = async (req, res) => {
@@ -49,7 +46,7 @@ const post = async (req, res) => {
     selectedRoles = [req.body.role];
   }
 
-  const uid = req.params.uid && !req.params.uid.startsWith('inv-') ? req.params.uid : undefined;
+  const uid = req.params.uid && !req.params.uid.startsWith("inv-") ? req.params.uid : undefined;
   const policyValidationResult = await policyEngine.validate(uid, req.params.oid, req.params.sid, selectedRoles, req.id);
   if (policyValidationResult.length > 0) {
     const model = await getViewModel(req);
@@ -59,14 +56,15 @@ const post = async (req, res) => {
       return roles;
     });
     model.validationMessages.roles = policyValidationResult.map((x) => x.message);
-    return res.render('services/views/associateService', model);
+    return res.render("services/views/associateService", model);
   }
 
   req.session.service = {
     roles: selectedRoles,
   };
 
-  return res.redirect('confirm-associate-service');
+  const returnOrgId = getReturnOrgId(req.query);
+  return res.redirect(`confirm-associate-service${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
 };
 
 module.exports = {

--- a/src/app/services/confirmAssociateService.js
+++ b/src/app/services/confirmAssociateService.js
@@ -1,10 +1,10 @@
-const NotificationClient = require('login.dfe.notifications.client');
-const config = require('../../infrastructure/config');
-const { getServiceById } = require('../../infrastructure/applications');
-const { listRolesOfService, addUserService, addInvitationService } = require('../../infrastructure/access');
-const { getUserDetails, getUserServiceRoles } = require('./utils');
-const { getOrganisationByIdV2, getUserOrganisations, getInvitationOrganisations } = require('../../infrastructure/organisations');
-const logger = require('../../infrastructure/logger');
+const NotificationClient = require("login.dfe.notifications.client");
+const config = require("../../infrastructure/config");
+const { getServiceById } = require("../../infrastructure/applications");
+const { listRolesOfService, addUserService, addInvitationService } = require("../../infrastructure/access");
+const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getOrganisationByIdV2, getUserOrganisations, getInvitationOrganisations } = require("../../infrastructure/organisations");
+const logger = require("../../infrastructure/logger");
 
 const getModel = async (req) => {
   const service = await getServiceById(req.params.sid, req.id);
@@ -15,23 +15,31 @@ const getModel = async (req) => {
   const user = await getUserDetails(req);
   const manageRolesForService = await getUserServiceRoles(req);
 
+  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}/associate-service`;
+  let cancelLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink += `?returnOrg=${returnOrgId}`;
+    cancelLink += `?returnOrg=${returnOrgId}`;
+  }
+
   return {
     csrfToken: req.csrfToken(),
-    backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}/associate-service`,
-    cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    backLink,
+    cancelLink,
     service,
     roles: roleDetails,
     user,
     organisation,
     serviceId: req.params.sid,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
+    currentNavigation: "users",
   };
 };
 
 const get = async (req, res) => {
   const model = await getModel(req);
-  return res.render('services/views/confirmAssociateService', model);
+  return res.render("services/views/confirmAssociateService", model);
 };
 
 const post = async (req, res) => {
@@ -41,11 +49,9 @@ const post = async (req, res) => {
   } = model;
 
   const selectedRoles = req.session.service.roles;
-  const invitationId = user.id.startsWith('inv-') ? user.id.substr(4) : undefined;
-  const userOrganisations = invitationId
-    ? await getInvitationOrganisations(invitationId, req.id)
-    : await getUserOrganisations(user.id, req.id);
-  const organisationDetails = userOrganisations.find(x => x.organisation.id === organisation.id);
+  const invitationId = user.id.startsWith("inv-") ? user.id.substr(4) : undefined;
+  const userOrganisations = invitationId ? await getInvitationOrganisations(invitationId, req.id) : await getUserOrganisations(user.id, req.id);
+  const organisationDetails = userOrganisations.find((x) => x.organisation.id === organisation.id);
   const userOrgPermission = {
     id: organisationDetails.role.id,
     name: organisationDetails.role.name,
@@ -69,26 +75,29 @@ const post = async (req, res) => {
   );
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) added service ${service.name} for organisation ${organisation.name} (id: ${model.organisation.id}) for user ${user.email} (id: ${user.id})`, {
-    type: 'manage',
-    subType: 'user-service-added',
+    type: "manage",
+    subType: "user-service-added",
     userId: req.user.sub,
     userEmail: req.user.email,
     organisationId: organisation.id,
-    editedFields: [{
-      name: 'add_services',
-      newValue: {
-        id: service.id,
-        roles: selectedRoles,
+    editedFields: [
+      {
+        name: "add_services",
+        newValue: {
+          id: service.id,
+          roles: selectedRoles,
+        },
       },
-    }],
+    ],
     editedUser: user.id,
   });
 
-  res.flash('title', 'Success');
-  res.flash('heading', `Service added: ${service.name}`);
-  res.flash('message', 'Approvers at the relevant organisation have been notified of this change.');
+  res.flash("title", "Success");
+  res.flash("heading", `Service added: ${service.name}`);
+  res.flash("message", "Approvers at the relevant organisation have been notified of this change.");
 
-  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
+  const returnOrgId = getReturnOrgId(req.query);
+  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
 };
 
 module.exports = {

--- a/src/app/services/confirmAssociateService.js
+++ b/src/app/services/confirmAssociateService.js
@@ -2,7 +2,7 @@ const NotificationClient = require("login.dfe.notifications.client");
 const config = require("../../infrastructure/config");
 const { getServiceById } = require("../../infrastructure/applications");
 const { listRolesOfService, addUserService, addInvitationService } = require("../../infrastructure/access");
-const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getUserDetails, getUserServiceRoles, getReturnUrl } = require("./utils");
 const { getOrganisationByIdV2, getUserOrganisations, getInvitationOrganisations } = require("../../infrastructure/organisations");
 const logger = require("../../infrastructure/logger");
 
@@ -15,18 +15,10 @@ const getModel = async (req) => {
   const user = await getUserDetails(req);
   const manageRolesForService = await getUserServiceRoles(req);
 
-  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}/associate-service`;
-  let cancelLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-    cancelLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return {
     csrfToken: req.csrfToken(),
-    backLink,
-    cancelLink,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}/associate-service`),
+    cancelLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`),
     service,
     roles: roleDetails,
     user,
@@ -96,8 +88,7 @@ const post = async (req, res) => {
   res.flash("heading", `Service added: ${service.name}`);
   res.flash("message", "Approvers at the relevant organisation have been notified of this change.");
 
-  const returnOrgId = getReturnOrgId(req.query);
-  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+  return res.redirect(getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`));
 };
 
 module.exports = {

--- a/src/app/services/confirmEditService.js
+++ b/src/app/services/confirmEditService.js
@@ -1,6 +1,6 @@
 const { getServiceById } = require("../../infrastructure/applications");
 const { listRolesOfService, updateUserService, updateInvitationService } = require("../../infrastructure/access");
-const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getUserDetails, getUserServiceRoles, getReturnUrl } = require("./utils");
 const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 const logger = require("../../infrastructure/logger");
 
@@ -13,18 +13,10 @@ const getModel = async (req) => {
   const user = await getUserDetails(req);
   const manageRolesForService = await getUserServiceRoles(req);
 
-  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}`;
-  let cancelLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-    cancelLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return {
     csrfToken: req.csrfToken(),
-    backLink,
-    cancelLink,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}`),
+    cancelLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`),
     service,
     roles: roleDetails,
     user,
@@ -71,8 +63,7 @@ const post = async (req, res) => {
   res.flash("heading", `Service updated: ${model.service.name}`);
   res.flash("message", "Approvers at the relevant organisation have been notified of this change.");
 
-  const returnOrgId = getReturnOrgId(req.query);
-  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+  return res.redirect(getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`));
 };
 
 module.exports = {

--- a/src/app/services/editService.js
+++ b/src/app/services/editService.js
@@ -2,7 +2,9 @@ const PolicyEngine = require("login.dfe.policy-engine");
 const config = require("../../infrastructure/config");
 const { getSingleUserService, getSingleInvitationService } = require("../../infrastructure/access");
 const { getServiceById } = require("../../infrastructure/applications");
-const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const {
+  getUserDetails, getUserServiceRoles, getReturnUrl, getReturnOrgId
+} = require("./utils");
 const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 
 const policyEngine = new PolicyEngine(config);
@@ -25,12 +27,6 @@ const getViewModel = async (req) => {
   const serviceRoles = policyResult.rolesAvailableToUser;
   const manageRolesForService = await getUserServiceRoles(req);
 
-  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return {
     csrfToken: req.csrfToken(),
     service: {
@@ -40,8 +36,8 @@ const getViewModel = async (req) => {
     serviceRoles,
     selectedRoles: [],
     user,
-    backLink,
-    returnOrgId,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`),
+    returnOrgId: getReturnOrgId(req.query),
     organisation,
     userService,
     validationMessages: {},
@@ -83,8 +79,8 @@ const post = async (req, res) => {
   req.session.service = {
     roles: selectedRoles,
   };
-  const returnOrgId = getReturnOrgId(req.query);
-  return res.redirect(`${req.params.oid}/confirm-edit-service${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+
+  return res.redirect(getReturnUrl(req.query, `${req.params.oid}/confirm-edit-service`));
 };
 
 module.exports = {

--- a/src/app/services/editService.js
+++ b/src/app/services/editService.js
@@ -1,15 +1,14 @@
-const PolicyEngine = require('login.dfe.policy-engine');
-const config = require('../../infrastructure/config');
-const { getSingleUserService, getSingleInvitationService } = require('../../infrastructure/access');
-const { getServiceById } = require('../../infrastructure/applications');
-const { getUserDetails, getUserServiceRoles } = require('./utils');
-const { getOrganisationByIdV2 } = require('../../infrastructure/organisations');
+const PolicyEngine = require("login.dfe.policy-engine");
+const config = require("../../infrastructure/config");
+const { getSingleUserService, getSingleInvitationService } = require("../../infrastructure/access");
+const { getServiceById } = require("../../infrastructure/applications");
+const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 
 const policyEngine = new PolicyEngine(config);
 
 const getSingleServiceForUser = async (userId, organisationId, serviceId, correlationId) => {
-  const userService = userId.startsWith('inv-') ? await getSingleInvitationService(userId.substr(4), serviceId, organisationId, correlationId)
-    : await getSingleUserService(userId, serviceId, organisationId, correlationId);
+  const userService = userId.startsWith("inv-") ? await getSingleInvitationService(userId.substr(4), serviceId, organisationId, correlationId) : await getSingleUserService(userId, serviceId, organisationId, correlationId);
   const application = await getServiceById(userService.serviceId);
   return {
     id: userService.serviceId,
@@ -22,13 +21,18 @@ const getViewModel = async (req) => {
   const user = await getUserDetails(req);
   const organisation = await getOrganisationByIdV2(req.params.oid, req.id);
   const userService = await getSingleServiceForUser(req.params.uid, req.params.oid, req.params.sid, req.id);
-  const policyResult = await policyEngine.getPolicyApplicationResultsForUser(req.params.uid.startsWith('inv-') ? undefined : req.params.uid, req.params.oid, req.params.sid, req.id);
+  const policyResult = await policyEngine.getPolicyApplicationResultsForUser(req.params.uid.startsWith("inv-") ? undefined : req.params.uid, req.params.oid, req.params.sid, req.id);
   const serviceRoles = policyResult.rolesAvailableToUser;
   const manageRolesForService = await getUserServiceRoles(req);
 
+  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink += `?returnOrg=${returnOrgId}`;
+  }
+
   return {
     csrfToken: req.csrfToken(),
-    cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
     service: {
       name: userService.name,
       id: userService.id,
@@ -36,13 +40,14 @@ const getViewModel = async (req) => {
     serviceRoles,
     selectedRoles: [],
     user,
-    backLink: true,
+    backLink,
+    returnOrgId,
     organisation,
     userService,
     validationMessages: {},
     serviceId: req.params.sid,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
+    currentNavigation: "users",
   };
 };
 
@@ -53,7 +58,7 @@ const get = async (req, res) => {
   }
 
   model.service.roles = model.userService.roles;
-  return res.render('services/views/editService', model);
+  return res.render("services/views/editService", model);
 };
 
 const post = async (req, res) => {
@@ -62,7 +67,7 @@ const post = async (req, res) => {
     selectedRoles = [req.body.role];
   }
 
-  const uid = req.params.uid && !req.params.uid.startsWith('inv-') ? req.params.uid : undefined;
+  const uid = req.params.uid && !req.params.uid.startsWith("inv-") ? req.params.uid : undefined;
   const policyValidationResult = await policyEngine.validate(uid, req.params.oid, req.params.sid, selectedRoles, req.id);
   if (policyValidationResult.length > 0) {
     const model = await getViewModel(req);
@@ -72,13 +77,14 @@ const post = async (req, res) => {
       return roles;
     });
     model.validationMessages.roles = policyValidationResult.map((x) => x.message);
-    return res.render('services/views/editService', model);
+    return res.render("services/views/editService", model);
   }
 
   req.session.service = {
     roles: selectedRoles,
   };
-  return res.redirect(`${req.params.oid}/confirm-edit-service`);
+  const returnOrgId = getReturnOrgId(req.query);
+  return res.redirect(`${req.params.oid}/confirm-edit-service${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
 };
 
 module.exports = {

--- a/src/app/services/getAudit.js
+++ b/src/app/services/getAudit.js
@@ -1,17 +1,17 @@
-const { mapUserStatus } = require('./../../infrastructure/utils');
-const { getUserDetailsById, getUserServiceRoles } = require('./utils');
-const { getPageOfUserAudits, cache } = require('./../../infrastructure/audit');
-const logger = require('./../../infrastructure/logger');
-const { getServiceIdForClientId } = require('./../../infrastructure/serviceMapping');
-const { getServiceById } = require('./../../infrastructure/applications');
-const { getOrganisationById, getUserOrganisations } = require('./../../infrastructure/organisations');
+const { mapUserStatus } = require("../../infrastructure/utils");
+const { getUserDetailsById, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const { getPageOfUserAudits } = require("../../infrastructure/audit");
+const logger = require("../../infrastructure/logger");
+const { getServiceIdForClientId } = require("../../infrastructure/serviceMapping");
+const { getServiceById } = require("../../infrastructure/applications");
+const { getOrganisationById, getUserOrganisations } = require("../../infrastructure/organisations");
 
 let cachedServiceIds = {};
 let cachedServices = {};
 let cachedUsers = {};
 
 const getCachedUserById = async (userId, reqId) => {
-  let key = `${userId}:${reqId}`;
+  const key = `${userId}:${reqId}`;
   if (!(key in cachedUsers)) {
     const user = await getUserDetailsById(userId, reqId);
     cachedUsers[key] = user;
@@ -22,83 +22,84 @@ const getCachedUserById = async (userId, reqId) => {
 const describeAuditEvent = async (audit, req) => {
   const isCurrentUser = audit.userId.toLowerCase() === req.params.uid.toLowerCase();
 
-  if (audit.type === 'sign-in') {
-    let description = 'Sign-in';
+  if (audit.type === "sign-in") {
+    let description = "Sign-in";
     switch (audit.subType) {
-      case 'username-password':
-        description += ' using email address and password';
+      case "username-password":
+        description += " using email address and password";
         break;
-      case 'digipass':
-        description += ' using a digipass key fob';
+      case "digipass":
+        description += " using a digipass key fob";
+        break;
+      default:
         break;
     }
     return description;
   }
 
-  if (audit.type === 'Sign-out') {
+  if (audit.type === "Sign-out") {
     return audit.type;
   }
 
-  if (audit.type === 'support' && audit.subType === 'user-edit') {
-    const viewedUser = audit.editedUser ? await getCachedUserById(audit.editedUser, req.id) : '';
-    const editedStatusTo = audit.editedFields && audit.editedFields.find(x => x.name === 'status');
+  if (audit.type === "support" && audit.subType === "user-edit") {
+    const viewedUser = audit.editedUser ? await getCachedUserById(audit.editedUser, req.id) : "";
+    const editedStatusTo = audit.editedFields && audit.editedFields.find((x) => x.name === "status");
     if (editedStatusTo && editedStatusTo.newValue === 0) {
       const newStatus = mapUserStatus(editedStatusTo.newValue);
-      const reason = audit.reason ? audit.reason : 'no reason given';
-      return isCurrentUser ? `${newStatus.description} user: ${viewedUser.firstName} ${viewedUser.lastName} (reason: ${reason})`
-        : ` Account ${newStatus.description} (reason: ${reason})`
+      const reason = audit.reason ? audit.reason : "no reason given";
+      return isCurrentUser ? `${newStatus.description} user: ${viewedUser.firstName} ${viewedUser.lastName} (reason: ${reason})` : ` Account ${newStatus.description} (reason: ${reason})`;
     }
     if (editedStatusTo && editedStatusTo.newValue === 1) {
-      return isCurrentUser ? `Reactivated user: ${viewedUser.firstName} ${viewedUser.lastName}` : `Account Reactivated`
+      return isCurrentUser ? `Reactivated user: ${viewedUser.firstName} ${viewedUser.lastName}` : "Account Reactivated";
     }
     if (editedStatusTo) {
       const newStatus = mapUserStatus(editedStatusTo.newValue);
       return newStatus.description;
     }
-    return 'Edited user';
+    return "Edited user";
   }
 
-  if (audit.type === 'support' && audit.subType === 'user-view') {
-    const viewedUser = audit.viewedUser ?  await getCachedUserById(audit.viewedUser, req.id) : '';
+  if (audit.type === "support" && audit.subType === "user-view") {
+    const viewedUser = audit.viewedUser ? await getCachedUserById(audit.viewedUser, req.id) : "";
     return `Viewed user ${viewedUser.firstName} ${viewedUser.lastName}`;
   }
 
-  if (audit.type === 'support' && audit.subType === 'user-search') {
+  if (audit.type === "support" && audit.subType === "user-search") {
     return `Searched for users using criteria "${audit.criteria}"`;
   }
 
-  if (audit.type === 'change-email' && audit.success) {
-    return 'Changed email';
+  if (audit.type === "change-email" && audit.success) {
+    return "Changed email";
   }
 
-  if (audit.type === 'change-password') {
-    return 'Changed password';
+  if (audit.type === "change-password") {
+    return "Changed password";
   }
 
-  if (audit.type === 'reset-password') {
-    return 'Reset password';
+  if (audit.type === "reset-password") {
+    return "Reset password";
   }
 
-  if (audit.type === 'change-name') {
-    return 'Changed name'
+  if (audit.type === "change-name") {
+    return "Changed name";
   }
 
-  if (audit.type === 'support' && audit.subType === 'user-org-deleted') {
-    const organisationId = audit.editedFields && audit.editedFields.find(x => x.name === 'new_organisation');
+  if (audit.type === "support" && audit.subType === "user-org-deleted") {
+    const organisationId = audit.editedFields && audit.editedFields.find((x) => x.name === "new_organisation");
     const organisation = await getOrganisationById(organisationId.oldValue);
     const viewedUser = await getCachedUserById(audit.editedUser, req.id);
-    return `Deleted organisation: ${organisation.name} for user  ${viewedUser.firstName} ${viewedUser.lastName}`
+    return `Deleted organisation: ${organisation.name} for user  ${viewedUser.firstName} ${viewedUser.lastName}`;
   }
-  if (audit.type === 'support' && audit.subType === 'user-org') {
-    const organisationId = audit.editedFields && audit.editedFields.find(x => x.name === 'new_organisation');
+  if (audit.type === "support" && audit.subType === "user-org") {
+    const organisationId = audit.editedFields && audit.editedFields.find((x) => x.name === "new_organisation");
     const organisation = await getOrganisationById(organisationId.newValue);
     const viewedUser = await getCachedUserById(audit.editedUser, req.id);
-    return `Added organisation: ${organisation.name} for user ${viewedUser.firstName} ${viewedUser.lastName}`
+    return `Added organisation: ${organisation.name} for user ${viewedUser.firstName} ${viewedUser.lastName}`;
   }
-  if (audit.type === 'support' && audit.subType === 'user-org-permission-edited') {
-    const editedFields = audit.editedFields && audit.editedFields.find(x => x.name === 'edited_permission');
+  if (audit.type === "support" && audit.subType === "user-org-permission-edited") {
+    const editedFields = audit.editedFields && audit.editedFields.find((x) => x.name === "edited_permission");
     const viewedUser = await getCachedUserById(audit.editedUser, req.id);
-    return `Edited permission level to ${editedFields.newValue} for user ${viewedUser.firstName} ${viewedUser.lastName} in organisation ${editedFields.organisation}`
+    return `Edited permission level to ${editedFields.newValue} for user ${viewedUser.firstName} ${viewedUser.lastName} in organisation ${editedFields.organisation}`;
   }
 
   return `${audit.type} / ${audit.subType}`;
@@ -112,7 +113,7 @@ const getCachedServiceIdForClientId = async (client) => {
 };
 
 const getCachedServiceById = async (serviceId, reqId) => {
-  let key = `${serviceId}:${reqId}`;
+  const key = `${serviceId}:${reqId}`;
   if (!(key in cachedServices)) {
     const service = await getServiceById(serviceId, reqId);
     cachedServices[key] = service;
@@ -130,14 +131,14 @@ const getAudit = async (req, res) => {
   const manageRolesForService = await getUserServiceRoles(req);
   const currentService = await getServiceById(req.params.sid, req.id);
 
-  const pageNumber = req.query && req.query.page ? parseInt(req.query.page) : 1;
-  if (isNaN(pageNumber)) {
+  const pageNumber = req.query && req.query.page ? parseInt(req.query.page, 10) : 1;
+  if (Number.isNaN(pageNumber)) {
     return res.status(400).send();
   }
   const pageOfAudits = await getPageOfUserAudits(user.id, pageNumber);
   const audits = [];
 
-  for (let i = 0; i < pageOfAudits.audits.length; i++) {
+  for (let i = 0; i < pageOfAudits.audits.length; i += 1) {
     const audit = pageOfAudits.audits[i];
     let service = null;
     let organisation = null;
@@ -147,12 +148,12 @@ const getAudit = async (req, res) => {
       const regex = /Authenticated .*? for (.+)/i;
       const match = regex.exec(audit.message);
       if (match !== null && match.length === 2) {
-        clientId = match[1];
+        [, clientId] = match;
       }
     }
     if (clientId) {
       // remove double quotes as new audit logger is adding them to string values
-      clientId = clientId.replace(/"/g, '');
+      clientId = clientId.replace(/"/g, "");
 
       const serviceId = await getCachedServiceIdForClientId(clientId);
       if (serviceId) {
@@ -180,18 +181,25 @@ const getAudit = async (req, res) => {
     });
   }
 
-  res.render('services/views/audit', {
+  let backLink = `/services/${req.params.sid}/users/${user.id}/organisations`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink += `?returnOrg=${returnOrgId}`;
+  }
+
+  return res.render("services/views/audit", {
     csrfToken: req.csrfToken(),
     user,
     organisations: userOrganisations,
     audits,
-    backLink: `/services/${req.params.sid}/users/${user.id}/organisations`,
+    backLink,
+    returnOrgId,
     numberOfPages: pageOfAudits.numberOfPages,
     page: pageNumber,
     totalNumberOfResults: pageOfAudits.numberOfRecords,
     serviceId: req.params.sid,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
+    currentNavigation: "users",
     currentService,
   });
 };

--- a/src/app/services/getAudit.js
+++ b/src/app/services/getAudit.js
@@ -1,5 +1,7 @@
 const { mapUserStatus } = require("../../infrastructure/utils");
-const { getUserDetailsById, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const {
+  getUserDetailsById, getUserServiceRoles, getReturnOrgId, getReturnUrl
+} = require("./utils");
 const { getPageOfUserAudits } = require("../../infrastructure/audit");
 const logger = require("../../infrastructure/logger");
 const { getServiceIdForClientId } = require("../../infrastructure/serviceMapping");
@@ -181,19 +183,13 @@ const getAudit = async (req, res) => {
     });
   }
 
-  let backLink = `/services/${req.params.sid}/users/${user.id}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return res.render("services/views/audit", {
     csrfToken: req.csrfToken(),
     user,
     organisations: userOrganisations,
     audits,
-    backLink,
-    returnOrgId,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${user.id}/organisations`),
+    returnOrgId: getReturnOrgId(req.query),
     numberOfPages: pageOfAudits.numberOfPages,
     page: pageNumber,
     totalNumberOfResults: pageOfAudits.numberOfRecords,

--- a/src/app/services/getUserOrganisations.js
+++ b/src/app/services/getUserOrganisations.js
@@ -1,11 +1,11 @@
-const flatten = require('lodash/flatten');
-const uniq = require('lodash/uniq');
-const { getAllUserOrganisations, getInvitationOrganisations } = require('../../infrastructure/organisations');
-const { getUsersByIdV2 } = require('../../infrastructure/directories');
-const { getUserDetails, getUserServiceRoles } = require('./utils');
-const logger = require('../../infrastructure/logger');
-const { getServiceById } = require('../../infrastructure/applications');
-const { getServicesForUser, getAllInvitationServices } = require('../../infrastructure/access');
+const flatten = require("lodash/flatten");
+const uniq = require("lodash/uniq");
+const { getAllUserOrganisations, getInvitationOrganisations } = require("../../infrastructure/organisations");
+const { getUsersByIdV2 } = require("../../infrastructure/directories");
+const { getUserDetails, getUserServiceRoles, getReturnOrgId } = require("./utils");
+const logger = require("../../infrastructure/logger");
+const { getServiceById } = require("../../infrastructure/applications");
+const { getServicesForUser, getAllInvitationServices } = require("../../infrastructure/access");
 
 const getApproverDetails = async (organisation, correlationId) => {
   const allApproverIds = flatten(organisation.map((org) => org.approvers));
@@ -18,89 +18,89 @@ const getApproverDetails = async (organisation, correlationId) => {
 };
 
 const getOrganisations = async (userId, correlationId) => {
-  const orgMapping = userId.startsWith('inv-') ? await getInvitationOrganisations(userId.substr(4), correlationId) : await getAllUserOrganisations(userId, correlationId);
+  const orgMapping = userId.startsWith("inv-") ? await getInvitationOrganisations(userId.substr(4), correlationId) : await getAllUserOrganisations(userId, correlationId);
   if (!orgMapping) {
     return [];
   }
 
-
   const allApprovers = await getApproverDetails(orgMapping, correlationId);
 
-  return Promise.all(orgMapping.map(async (invitation) => {
-    const approvers = invitation.approvers.map((approverId) => allApprovers.find((x) => x.sub.toLowerCase() === approverId.toLowerCase())).filter((x) => x);
+  return Promise.all(
+    orgMapping.map(async (invitation) => {
+      const approvers = invitation.approvers.map((approverId) => allApprovers.find((x) => x.sub.toLowerCase() === approverId.toLowerCase())).filter((x) => x);
 
-    const services = await Promise.all(invitation.services.map(async (service) => ({
-      id: service.id,
-      name: service.name,
-      userType: invitation.role,
-      grantedAccessOn: service.requestDate ? new Date(service.requestDate) : null,
-      serviceRoles: [],
-    })));
+      const services = await Promise.all(
+        invitation.services.map(async (service) => ({
+          id: service.id,
+          name: service.name,
+          userType: invitation.role,
+          grantedAccessOn: service.requestDate ? new Date(service.requestDate) : null,
+          serviceRoles: [],
+        })),
+      );
 
-    const selectedUserServices = userId.startsWith('inv-') ? await getAllInvitationServices(userId.substr(4),correlationId)
-    : await getServicesForUser(userId, correlationId);
+      const selectedUserServices = userId.startsWith("inv-") ? await getAllInvitationServices(userId.substr(4), correlationId) : await getServicesForUser(userId, correlationId);
 
-    const userOrgServices = selectedUserServices?.filter((s) => s.organisationId === invitation.organisation.id)|| [];
+      const userOrgServices = selectedUserServices?.filter((s) => s.organisationId === invitation.organisation.id) || [];
 
-    services.map((service) => {
-      const userServiceRole = userOrgServices.find((orgService) => service.id === orgService.serviceId);
-      if (userServiceRole) {
-        service.serviceRoles.push(...userServiceRole.roles);
-      }
-      return service;
-    });
-    return {
-      id: invitation.organisation.id,
-      name: invitation.organisation.name,
-      LegalName: invitation.organisation.LegalName,
-      status: invitation.organisation.status,
-      role: invitation.role,
-      urn: invitation.organisation.urn,
-      uid: invitation.organisation.uid,
-      ukprn: invitation.organisation.ukprn,
-      numericIdentifier: invitation.numericIdentifier,
-      textIdentifier: invitation.textIdentifier,
-      approvers,
-      services,
-    };
-  }));
+      services.map((service) => {
+        const userServiceRole = userOrgServices.find((orgService) => service.id === orgService.serviceId);
+        if (userServiceRole) {
+          service.serviceRoles.push(...userServiceRole.roles);
+        }
+        return service;
+      });
+      return {
+        id: invitation.organisation.id,
+        name: invitation.organisation.name,
+        LegalName: invitation.organisation.LegalName,
+        status: invitation.organisation.status,
+        role: invitation.role,
+        urn: invitation.organisation.urn,
+        uid: invitation.organisation.uid,
+        ukprn: invitation.organisation.ukprn,
+        numericIdentifier: invitation.numericIdentifier,
+        textIdentifier: invitation.textIdentifier,
+        approvers,
+        services,
+      };
+    }),
+  );
 };
 
 const getUserOrganisations = async (req, res) => {
   const user = await getUserDetails(req);
 
   const organisations = await getOrganisations(user.id, req.id);
-  const visibleOrganisations = organisations.filter(o => o.status?.id !== 0)
+  const visibleOrganisations = organisations.filter((o) => o.status?.id !== 0);
 
   const manageRolesForService = await getUserServiceRoles(req);
   const currentService = await getServiceById(req.params.sid, req.id);
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) viewed user ${user.email} (id: ${user.id})`, {
-    type: 'organisations',
-    subType: 'user-view',
+    type: "organisations",
+    subType: "user-view",
     userId: req.user.sub,
     userEmail: req.user.email,
     viewedUser: user.id,
   });
-  let links ='';
-    if(req.params.oid === undefined)
-    {
-       links = `/services/${req.params.sid}/users`;
-    }else{
-       links = `/services/${req.params.sid}/organisations/${req.params.oid}/users`;
-    }
- 
 
-  return res.render('services/views/userOrganisations', {
+  let backLink = `/services/${req.params.sid}/users`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink = `/services/${req.params.sid}/organisations/${returnOrgId}/users`;
+  }
+
+  return res.render("services/views/userOrganisations", {
     csrfToken: req.csrfToken(),
     user,
     organisations: visibleOrganisations,
-    isInvitation: req.params.uid.startsWith('inv-'),
-    backLink: links,
+    isInvitation: req.params.uid.startsWith("inv-"),
+    backLink,
     serviceId: req.params.sid,
-    currentOrgId: req.params.oid,
+    returnOrgId,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
+    currentNavigation: "users",
     currentService,
   });
 };

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -1,135 +1,132 @@
-'use strict';
+const express = require("express");
+const { asyncWrapper } = require("login.dfe.express-error-handling");
+const logger = require("../../infrastructure/logger");
+const {
+  isLoggedIn, isManageUserForService, hasRole, hasInvite
+} = require("../../infrastructure/utils");
 
-const express = require('express');
-const { asyncWrapper } = require('login.dfe.express-error-handling');
-const logger = require('../../infrastructure/logger');
-const { isLoggedIn, isManageUserForService, hasRole, hasInvite 
-} = require('../../infrastructure/utils');
+const { getDashboard } = require("./getDashboard");
+const getServiceInfo = require("./getServiceInfo");
+const { getServiceConfig, postServiceConfig } = require("./serviceConfig");
+const { getConfirmServiceConfig, postConfirmServiceConfig } = require("./confirmServiceConfig");
+const { get: getSelectService, post: postSelectService } = require("./selectService");
+const { get: getServiceBanners, post: postServiceBanners } = require("./serviceBanners");
+const { get: getNewServiceBanners, post: postNewServiceBanners } = require("./newServiceBanner");
+const { get: getDeleteBanner, post: postDeleteBanner } = require("./deleteServiceBanner");
+const { get: getUsersSearch, post: postUsersSearch } = require("./usersSearch");
+const getUserOrganisations = require("./getUserOrganisations");
+const { get: getWebServiceSync, post: postWebServiceSync } = require("./webServiceSync");
+const { get: getOrganisationsSearch, post: postOrganisationsSearch } = require("./organisationsSearch");
+const { get: getOrganisationUserList, post: postOrganisationUserList } = require("./organisationUserList");
+const { get: getWebServiceSyncOrg, post: postWebServiceSyncOrg } = require("./webServiceSyncOrg");
+const { get: getEditService, post: postEditService } = require("./editService");
+const { get: getConfirmEditService, post: postConfirmEditService } = require("./confirmEditService");
+const { get: getRemoveService, post: postRemoveService } = require("./removeService");
+const { get: getAssociateService, post: postAssociateService } = require("./associateService");
+const { get: getConfirmAssociateService, post: postConfirmAssociateService } = require("./confirmAssociateService");
+const { get: getListPolicies, post: postListPolicies } = require("./listPolicies");
+const getPolicyConditions = require("./getPolicyConditionsAndRoles");
 
-const { getDashboard } = require('./getDashboard');
-const getServiceInfo = require('./getServiceInfo');
-const { getServiceConfig, postServiceConfig } = require('./serviceConfig');
-const { getConfirmServiceConfig, postConfirmServiceConfig } = require('./confirmServiceConfig');
-const { get: getSelectService, post: postSelectService } = require('./selectService');
-const { get: getServiceBanners, post: postServiceBanners } = require('./serviceBanners');
-const { get: getNewServiceBanners, post: postNewServiceBanners } = require('./newServiceBanner');
-const { get: getDeleteBanner, post: postDeleteBanner } = require('./deleteServiceBanner');
-const { get: getUsersSearch, post: postUsersSearch } = require('./usersSearch');
-const getUserOrganisations = require('./getUserOrganisations');
-const { get: getWebServiceSync, post: postWebServiceSync } = require('./webServiceSync');
-const { get: getOrganisationsSearch, post: postOrganisationsSearch } = require('./organisationsSearch');
-const { get: getOrganisationUserList, post: postOrganisationUserList } = require('./organisationUserList');
-const { get: getWebServiceSyncOrg, post: postWebServiceSyncOrg } = require('./webServiceSyncOrg');
-const { get: getEditService, post: postEditService } = require('./editService');
-const { get: getConfirmEditService, post: postConfirmEditService } = require('./confirmEditService');
-const { get: getRemoveService, post: postRemoveService } = require('./removeService');
-const { get: getAssociateService, post: postAssociateService } = require('./associateService');
-const { get: getConfirmAssociateService, post: postConfirmAssociateService } = require('./confirmAssociateService');
-const { get: getListPolicies, post: postListPolicies } = require('./listPolicies');
-const getPolicyConditions = require('./getPolicyConditionsAndRoles');
-
-const { get: getAssociateRoles, post: postAssociateRoles } = require('./associateRoles');
-const { get: getConfirmInvitation, post: postConfirmInvitation } = require('./confirmInvitation');
-const getAudit = require('./getAudit');
-const postUpdateAuditLog = require('./postUpdateAuditLog');
+const { get: getAssociateRoles, post: postAssociateRoles } = require("./associateRoles");
+const { get: getConfirmInvitation, post: postConfirmInvitation } = require("./confirmInvitation");
+const getAudit = require("./getAudit");
+const postUpdateAuditLog = require("./postUpdateAuditLog");
 
 const router = express.Router({ mergeParams: true });
 
 const services = (csrf) => {
-  logger.info('Mounting services routes');
+  logger.info("Mounting services routes");
   router.use(isLoggedIn);
 
-  router.get('/', asyncWrapper((req, res) => {
-    if (!req.userServices || req.userServices.roles.length === 0) {
-      return res.status(401).render('errors/views/notAuthorised');
-    }
-    return res.redirect('services/select-service');
-  }));
+  router.get(
+    "/",
+    asyncWrapper((req, res) => {
+      if (!req.userServices || req.userServices.roles.length === 0) {
+        return res.status(401).render("errors/views/notAuthorised");
+      }
+      return res.redirect("services/select-service");
+    }),
+  );
 
-  router.get('/select-service', csrf, asyncWrapper(getSelectService));
-  router.post('/select-service', csrf, asyncWrapper(postSelectService));
+  router.get("/select-service", csrf, asyncWrapper(getSelectService));
+  router.post("/select-service", csrf, asyncWrapper(postSelectService));
 
-  router.get('/:sid', csrf, isManageUserForService, asyncWrapper(getDashboard));
+  router.get("/:sid", csrf, isManageUserForService, asyncWrapper(getDashboard));
 
   // service information
-  router.get('/:sid/service-information', csrf, isManageUserForService, asyncWrapper(getServiceInfo));
+  router.get("/:sid/service-information", csrf, isManageUserForService, asyncWrapper(getServiceInfo));
 
   // service config
-  router.get('/:sid/service-configuration', csrf, isManageUserForService, hasRole('serviceconfig'), asyncWrapper(getServiceConfig));
-  router.post('/:sid/service-configuration', csrf, isManageUserForService, hasRole('serviceconfig'), asyncWrapper(postServiceConfig));
+  router.get("/:sid/service-configuration", csrf, isManageUserForService, hasRole("serviceconfig"), asyncWrapper(getServiceConfig));
+  router.post("/:sid/service-configuration", csrf, isManageUserForService, hasRole("serviceconfig"), asyncWrapper(postServiceConfig));
 
   // service config
-  router.get('/:sid/review-service-configuration', csrf, isManageUserForService, hasRole('serviceconfig'), asyncWrapper(getConfirmServiceConfig));
-  router.post('/:sid/review-service-configuration', csrf, isManageUserForService, hasRole('serviceconfig'), asyncWrapper(postConfirmServiceConfig));
+  router.get("/:sid/review-service-configuration", csrf, isManageUserForService, hasRole("serviceconfig"), asyncWrapper(getConfirmServiceConfig));
+  router.post("/:sid/review-service-configuration", csrf, isManageUserForService, hasRole("serviceconfig"), asyncWrapper(postConfirmServiceConfig));
 
   // service banners
-  router.get('/:sid/service-banners', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(getServiceBanners));
-  router.post('/:sid/service-banners', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(postServiceBanners));
+  router.get("/:sid/service-banners", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(getServiceBanners));
+  router.post("/:sid/service-banners", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(postServiceBanners));
 
-  router.get('/:sid/service-banners/new-banner', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(getNewServiceBanners));
-  router.post('/:sid/service-banners/new-banner', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(postNewServiceBanners));
+  router.get("/:sid/service-banners/new-banner", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(getNewServiceBanners));
+  router.post("/:sid/service-banners/new-banner", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(postNewServiceBanners));
 
-  router.get('/:sid/service-banners/:bid', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(getNewServiceBanners));
-  router.post('/:sid/service-banners/:bid', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(postNewServiceBanners));
+  router.get("/:sid/service-banners/:bid", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(getNewServiceBanners));
+  router.post("/:sid/service-banners/:bid", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(postNewServiceBanners));
 
-  router.get('/:sid/service-banners/:bid/delete-banner', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(getDeleteBanner));
-  router.post('/:sid/service-banners/:bid/delete-banner', csrf, isManageUserForService, hasRole('serviceBanner'), asyncWrapper(postDeleteBanner));
+  router.get("/:sid/service-banners/:bid/delete-banner", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(getDeleteBanner));
+  router.post("/:sid/service-banners/:bid/delete-banner", csrf, isManageUserForService, hasRole("serviceBanner"), asyncWrapper(postDeleteBanner));
 
   // service support
-  router.get('/:sid/users', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getUsersSearch));
-  router.post('/:sid/users', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postUsersSearch));
+  router.get("/:sid/users", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getUsersSearch));
+  router.post("/:sid/users", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postUsersSearch));
 
-  router.get('/:sid/users/:uid/associate-roles', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(getAssociateRoles));
-  router.post('/:sid/users/:uid/associate-roles', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(postAssociateRoles));
+  router.get("/:sid/users/:uid/associate-roles", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(getAssociateRoles));
+  router.post("/:sid/users/:uid/associate-roles", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(postAssociateRoles));
 
-  router.get('/:sid/users/associate-roles', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(getAssociateRoles));
-  router.post('/:sid/users/associate-roles', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(postAssociateRoles));
+  router.get("/:sid/users/associate-roles", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(getAssociateRoles));
+  router.post("/:sid/users/associate-roles", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(postAssociateRoles));
 
-  router.get('/:sid/users/:uid/confirm-details', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(getConfirmInvitation));
-  router.post('/:sid/users/:uid/confirm-details', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(hasInvite), asyncWrapper(postConfirmInvitation));
+  router.get("/:sid/users/:uid/confirm-details", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(getConfirmInvitation));
+  router.post("/:sid/users/:uid/confirm-details", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(hasInvite), asyncWrapper(postConfirmInvitation));
 
-  router.get('/:sid/users/:uid/organisations', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getUserOrganisations));
-  router.get('/:sid/users/:uid/organisations/:oid/userDetails', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getUserOrganisations));
+  router.get("/:sid/users/:uid/organisations", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getUserOrganisations));
 
-  router.get('/:sid/users/:uid/organisations/:oid', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getEditService));
-  router.post('/:sid/users/:uid/organisations/:oid', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postEditService));
+  router.get("/:sid/users/:uid/organisations/:oid", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getEditService));
+  router.post("/:sid/users/:uid/organisations/:oid", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postEditService));
 
-  router.get('/:sid/users/:uid/organisations/:oid/confirm-edit-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getConfirmEditService));
-  router.post('/:sid/users/:uid/organisations/:oid/confirm-edit-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postConfirmEditService));
+  router.get("/:sid/users/:uid/organisations/:oid/confirm-edit-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getConfirmEditService));
+  router.post("/:sid/users/:uid/organisations/:oid/confirm-edit-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postConfirmEditService));
 
-  router.get('/:sid/users/:uid/organisations/:oid/remove-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getRemoveService));
-  router.post('/:sid/users/:uid/organisations/:oid/remove-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postRemoveService));
+  router.get("/:sid/users/:uid/organisations/:oid/remove-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getRemoveService));
+  router.post("/:sid/users/:uid/organisations/:oid/remove-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postRemoveService));
 
-  router.get('/:sid/users/:uid/organisations/:oid/associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getAssociateService));
-  router.post('/:sid/users/:uid/organisations/:oid/associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postAssociateService));
+  router.get("/:sid/users/:uid/organisations/:oid/associate-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getAssociateService));
+  router.post("/:sid/users/:uid/organisations/:oid/associate-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postAssociateService));
 
-  router.get('/:sid/users/:uid/organisations/:oid/:currentIod/associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getAssociateService));
-  router.post('/:sid/users/:uid/organisations/:oid/:coid/associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postAssociateService));
+  router.get("/:sid/users/:uid/organisations/:oid/confirm-associate-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getConfirmAssociateService));
+  router.post("/:sid/users/:uid/organisations/:oid/confirm-associate-service", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postConfirmAssociateService));
 
-  router.get('/:sid/users/:uid/organisations/:oid/confirm-associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getConfirmAssociateService));
-  router.post('/:sid/users/:uid/organisations/:oid/confirm-associate-service', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postConfirmAssociateService));
+  router.get("/:sid/users/:uid/web-service-sync", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getWebServiceSync));
+  router.post("/:sid/users/:uid/web-service-sync", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postWebServiceSync));
 
-  router.get('/:sid/users/:uid/web-service-sync',csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getWebServiceSync));
-  router.post('/:sid/users/:uid/web-service-sync',csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postWebServiceSync));
+  router.get("/:sid/users/:uid/audit", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getAudit));
+  router.post("/:sid/users/:uid/audit", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postUpdateAuditLog));
 
-  router.get('/:sid/users/:uid/audit', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getAudit));
-  router.post('/:sid/users/:uid/audit', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postUpdateAuditLog));
+  router.get("/:sid/organisations", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getOrganisationsSearch));
+  router.post("/:sid/organisations", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postOrganisationsSearch));
 
-  router.get('/:sid/organisations', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getOrganisationsSearch));
-  router.post('/:sid/organisations', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postOrganisationsSearch));
+  router.get("/:sid/organisations/:oid/users", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getOrganisationUserList));
+  router.post("/:sid/organisations/:oid/users", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postOrganisationUserList));
 
-  router.get('/:sid/organisations/:oid/users', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getOrganisationUserList));
-  router.post('/:sid/organisations/:oid/users', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postOrganisationUserList));
-
-  router.get('/:sid/organisations/:oid/web-service-sync', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(getWebServiceSyncOrg));
-  router.post('/:sid/organisations/:oid/web-service-sync', csrf, isManageUserForService, hasRole('serviceSup'), asyncWrapper(postWebServiceSyncOrg));
+  router.get("/:sid/organisations/:oid/web-service-sync", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(getWebServiceSyncOrg));
+  router.post("/:sid/organisations/:oid/web-service-sync", csrf, isManageUserForService, hasRole("serviceSup"), asyncWrapper(postWebServiceSyncOrg));
 
   // service access management
-  router.get('/:sid/policies', csrf, isManageUserForService, hasRole('accessManage'), asyncWrapper(getListPolicies));
-  router.post('/:sid/policies', csrf, isManageUserForService, hasRole('accessManage'), asyncWrapper(postListPolicies));
+  router.get("/:sid/policies", csrf, isManageUserForService, hasRole("accessManage"), asyncWrapper(getListPolicies));
+  router.post("/:sid/policies", csrf, isManageUserForService, hasRole("accessManage"), asyncWrapper(postListPolicies));
 
-  router.get('/:sid/policies/:pid/conditionsAndRoles', csrf, isManageUserForService, hasRole('accessManage'), asyncWrapper(getPolicyConditions));
-
+  router.get("/:sid/policies/:pid/conditionsAndRoles", csrf, isManageUserForService, hasRole("accessManage"), asyncWrapper(getPolicyConditions));
 
   return router;
 };

--- a/src/app/services/organisationUserList.js
+++ b/src/app/services/organisationUserList.js
@@ -1,50 +1,50 @@
-const { searchForUsers } = require('../../infrastructure/search');
-const { getOrganisationByIdV2 } = require('../../infrastructure/organisations');
-const { mapUserRole } = require('../../infrastructure/utils');
-const { getUserServiceRoles } = require('./utils');
-const { getServiceById } = require('../../infrastructure/applications');
+const { searchForUsers } = require("../../infrastructure/search");
+const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
+const { mapUserRole } = require("../../infrastructure/utils");
+const { getUserServiceRoles } = require("./utils");
+const { getServiceById } = require("../../infrastructure/applications");
 
 const search = async (req) => {
   const organisationId = req.params.oid;
-  const paramsSource = req.method === 'POST' ? req.body : req.query;
+  const paramsSource = req.method === "POST" ? req.body : req.query;
 
   let page = paramsSource.page ? parseInt(paramsSource.page, 10) : 1;
-  if (isNaN(page)) {
+  if (Number.isNaN(page)) {
     page = 1;
   }
 
-  const availableSortCriteria = ['name', 'email', 'lastlogin', 'status'];
+  const availableSortCriteria = ["name", "email", "lastlogin", "status"];
 
-  const sortBy = (paramsSource.sort && availableSortCriteria.includes(paramsSource.sort.toLowerCase())) ? paramsSource.sort.toLowerCase() : 'name';
-  const sortAsc = (paramsSource.sortDir ? paramsSource.sortDir : 'asc').toLowerCase() === 'asc';
+  const sortBy = paramsSource.sort && availableSortCriteria.includes(paramsSource.sort.toLowerCase()) ? paramsSource.sort.toLowerCase() : "name";
+  const sortAsc = (paramsSource.sortDir ? paramsSource.sortDir : "asc").toLowerCase() === "asc";
 
-  const results = await searchForUsers('*', page, sortBy, sortAsc ? 'asc' : 'desc', {
+  const results = await searchForUsers("*", page, sortBy, sortAsc ? "asc" : "desc", {
     organisations: [organisationId],
   });
 
   return {
     page,
     sortBy,
-    sortOrder: sortAsc ? 'asc' : 'desc',
+    sortOrder: sortAsc ? "asc" : "desc",
     numberOfPages: results.numberOfPages,
     totalNumberOfResults: results.totalNumberOfResults,
     users: results.users,
     sort: {
       name: {
-        nextDirection: sortBy === 'name' ? (sortAsc ? 'desc' : 'asc') : 'asc',
-        applied: sortBy === 'name',
+        nextDirection: sortBy === "name" ? (sortAsc ? "desc" : "asc") : "asc",
+        applied: sortBy === "name",
       },
       email: {
-        nextDirection: sortBy === 'email' ? (sortAsc ? 'desc' : 'asc') : 'asc',
-        applied: sortBy === 'email',
+        nextDirection: sortBy === "email" ? (sortAsc ? "desc" : "asc") : "asc",
+        applied: sortBy === "email",
       },
       lastLogin: {
-        nextDirection: sortBy === 'lastlogin' ? (sortAsc ? 'desc' : 'asc') : 'asc',
-        applied: sortBy === 'lastlogin',
+        nextDirection: sortBy === "lastlogin" ? (sortAsc ? "desc" : "asc") : "asc",
+        applied: sortBy === "lastlogin",
       },
       status: {
-        nextDirection: sortBy === 'status' ? (sortAsc ? 'desc' : 'asc') : 'asc',
-        applied: sortBy === 'status',
+        nextDirection: sortBy === "status" ? (sortAsc ? "desc" : "asc") : "asc",
+        applied: sortBy === "status",
       },
     },
   };
@@ -63,13 +63,12 @@ const render = async (req, res) => {
     return viewUser;
   });
 
-  return res.render('services/views/organisationUserList', {
+  return res.render("services/views/organisationUserList", {
     csrfToken: req.csrfToken(),
     serviceId: req.params.sid,
     service,
     backLink: `/services/${req.params.sid}/organisations`,
     organisation,
-    currentOrgId: req.params.oid,
     users,
     page: result.page,
     numberOfPages: result.numberOfPages,
@@ -78,7 +77,7 @@ const render = async (req, res) => {
     userRoles: manageRolesForService,
     sort: result.sort,
     sortBy: result.sortBy,
-    currentNavigation: 'organisations',
+    currentNavigation: "organisations",
   });
 };
 

--- a/src/app/services/postUpdateAuditLog.js
+++ b/src/app/services/postUpdateAuditLog.js
@@ -1,8 +1,10 @@
-const { api } = require('./../../infrastructure/audit');
+const { api } = require("../../infrastructure/audit");
+const { getReturnOrgId } = require("./utils");
 
 const postUpdateAuditLog = async (req, res) => {
   await api.updateAuditLogs();
-  res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/audit`);
+  const returnOrgId = getReturnOrgId(req.query);
+  res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/audit${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
 };
 
 module.exports = postUpdateAuditLog;

--- a/src/app/services/postUpdateAuditLog.js
+++ b/src/app/services/postUpdateAuditLog.js
@@ -1,10 +1,9 @@
 const { api } = require("../../infrastructure/audit");
-const { getReturnOrgId } = require("./utils");
+const { getReturnUrl } = require("./utils");
 
 const postUpdateAuditLog = async (req, res) => {
   await api.updateAuditLogs();
-  const returnOrgId = getReturnOrgId(req.query);
-  res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/audit${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+  res.redirect(getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/audit`));
 };
 
 module.exports = postUpdateAuditLog;

--- a/src/app/services/removeService.js
+++ b/src/app/services/removeService.js
@@ -1,10 +1,12 @@
-const { removeServiceFromUser, removeServiceFromInvitation } = require('../../infrastructure/access');
-const { getServiceById } = require('../../infrastructure/applications');
-const { getUserDetails, waitForIndexToUpdate, getUserServiceRoles } = require('./utils');
-const { getOrganisationByIdV2 } = require('../../infrastructure/organisations');
-const { getSearchDetailsForUserById, updateIndex } = require('../../infrastructure/search');
+const { removeServiceFromUser, removeServiceFromInvitation } = require("../../infrastructure/access");
+const { getServiceById } = require("../../infrastructure/applications");
+const {
+  getUserDetails, waitForIndexToUpdate, getUserServiceRoles, getReturnOrgId
+} = require("./utils");
+const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
+const { getSearchDetailsForUserById, updateIndex } = require("../../infrastructure/search");
 
-const logger = require('../../infrastructure/logger');
+const logger = require("../../infrastructure/logger");
 
 const getModel = async (req) => {
   const service = await getServiceById(req.params.sid, req.id);
@@ -12,29 +14,40 @@ const getModel = async (req) => {
   const organisation = await getOrganisationByIdV2(req.params.oid, req.id);
   const manageRolesForService = await getUserServiceRoles(req);
 
+  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}`;
+  let cancelLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
+  const returnOrgId = getReturnOrgId(req.query);
+  if (returnOrgId !== null) {
+    backLink += `?returnOrg=${returnOrgId}`;
+    cancelLink += `?returnOrg=${returnOrgId}`;
+  }
+
   return {
-    backLink: true,
-    cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    backLink,
+    cancelLink,
     csrfToken: req.csrfToken(),
     organisation,
     user,
     service,
     serviceId: req.params.sid,
     userRoles: manageRolesForService,
-    currentNavigation: 'users',
-
+    currentNavigation: "users",
   };
 };
 
 const get = async (req, res) => {
   const model = await getModel(req);
-  return res.render('services/views/removeService', model);
+  return res.render("services/views/removeService", model);
 };
 
 const post = async (req, res) => {
   const model = await getModel(req);
-  req.params.uid.startsWith('inv-') ? await removeServiceFromInvitation(req.params.uid.substr(4), req.params.sid, req.params.oid, req.id)
-    : await removeServiceFromUser(req.params.uid, req.params.sid, req.params.oid, req.id);
+
+  if (req.params.uid.startsWith("inv-")) {
+    await removeServiceFromInvitation(req.params.uid.substr(4), req.params.sid, req.params.oid, req.id);
+  } else {
+    await removeServiceFromUser(req.params.uid, req.params.sid, req.params.oid, req.id);
+  }
 
   const getAllUserDetails = await getSearchDetailsForUserById(req.params.uid, req.id);
   const currentServiceDetails = getAllUserDetails.services;
@@ -44,20 +57,23 @@ const post = async (req, res) => {
   await waitForIndexToUpdate(req.params.uid, (updated) => updated.services.length === updatedServiceDetails.length);
 
   logger.audit(`${req.user.email} (id: ${req.user.sub}) removed service ${model.service.name} for organisation ${model.organisation.name} (id: ${model.organisation.id}) for user ${model.user.email} (id: ${model.user.id})`, {
-    type: 'manage',
-    subType: 'user-service-deleted',
+    type: "manage",
+    subType: "user-service-deleted",
     userId: req.user.sub,
     userEmail: req.user.email,
     editedUser: model.user.id,
-    editedFields: [{
-      name: 'remove_service',
-      oldValue: model.service.id,
-      newValue: undefined,
-    }],
+    editedFields: [
+      {
+        name: "remove_service",
+        oldValue: model.service.id,
+        newValue: undefined,
+      },
+    ],
   });
 
-  res.flash('info', `${model.user.firstName} ${model.user.lastName} removed from ${model.service.name}`);
-  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
+  res.flash("info", `${model.user.firstName} ${model.user.lastName} removed from ${model.service.name}`);
+  const returnOrgId = getReturnOrgId(req.query);
+  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
 };
 
 module.exports = {

--- a/src/app/services/removeService.js
+++ b/src/app/services/removeService.js
@@ -1,7 +1,7 @@
 const { removeServiceFromUser, removeServiceFromInvitation } = require("../../infrastructure/access");
 const { getServiceById } = require("../../infrastructure/applications");
 const {
-  getUserDetails, waitForIndexToUpdate, getUserServiceRoles, getReturnOrgId
+  getUserDetails, waitForIndexToUpdate, getUserServiceRoles, getReturnUrl
 } = require("./utils");
 const { getOrganisationByIdV2 } = require("../../infrastructure/organisations");
 const { getSearchDetailsForUserById, updateIndex } = require("../../infrastructure/search");
@@ -14,17 +14,9 @@ const getModel = async (req) => {
   const organisation = await getOrganisationByIdV2(req.params.oid, req.id);
   const manageRolesForService = await getUserServiceRoles(req);
 
-  let backLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}`;
-  let cancelLink = `/services/${req.params.sid}/users/${req.params.uid}/organisations`;
-  const returnOrgId = getReturnOrgId(req.query);
-  if (returnOrgId !== null) {
-    backLink += `?returnOrg=${returnOrgId}`;
-    cancelLink += `?returnOrg=${returnOrgId}`;
-  }
-
   return {
-    backLink,
-    cancelLink,
+    backLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations/${organisation.id}`),
+    cancelLink: getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`),
     csrfToken: req.csrfToken(),
     organisation,
     user,
@@ -72,8 +64,8 @@ const post = async (req, res) => {
   });
 
   res.flash("info", `${model.user.firstName} ${model.user.lastName} removed from ${model.service.name}`);
-  const returnOrgId = getReturnOrgId(req.query);
-  return res.redirect(`/services/${req.params.sid}/users/${req.params.uid}/organisations${returnOrgId !== null ? `?returnOrg=${returnOrgId}` : ""}`);
+
+  return res.redirect(getReturnUrl(req.query, `/services/${req.params.sid}/users/${req.params.uid}/organisations`));
 };
 
 module.exports = {

--- a/src/app/services/utils.js
+++ b/src/app/services/utils.js
@@ -283,8 +283,8 @@ const getFriendlyValues = async (fieldName, values, correlationId) => {
 };
 
 const delay = async (milliseconds) => new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
+  setTimeout(resolve, milliseconds);
+});
 
 const waitForIndexToUpdate = async (uid, updatedCheck) => {
   const abandonTime = Date.now() + 10000;
@@ -429,16 +429,16 @@ const getValidPageNumber = (pageSource) => {
 };
 
 const objectToQueryString = (obj) => Object.entries(obj)
-    .flatMap(([key, value]) => {
-      if (Array.isArray(value)) {
-        return value.filter((v) => v !== undefined && v !== null && v !== "").map((v) => `${key}=${v}`);
-      }
-      if (value !== undefined && value !== null && value !== "") {
-        return `${key}=${value}`;
-      }
-      return [];
-    })
-    .join("&");
+  .flatMap(([key, value]) => {
+    if (Array.isArray(value)) {
+      return value.filter((v) => v !== undefined && v !== null && v !== "").map((v) => `${key}=${v}`);
+    }
+    if (value !== undefined && value !== null && value !== "") {
+      return `${key}=${value}`;
+    }
+    return [];
+  })
+  .join("&");
 
 const arraysEqual = (a, b) => {
   if (a.length !== b.length) return false;
@@ -498,6 +498,18 @@ const checkClientId = async (clientId, reqId) => {
   return !!service;
 };
 
+const getReturnOrgId = (requestQuery) => {
+  if (
+    requestQuery
+    && Object.prototype.hasOwnProperty.call(requestQuery, "returnOrg")
+    && typeof requestQuery.returnOrg === "string"
+    && requestQuery.returnOrg.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+  ) {
+    return requestQuery.returnOrg;
+  }
+  return null;
+};
+
 module.exports = {
   mapUserToSupportModel,
   getUserDetails,
@@ -522,4 +534,5 @@ module.exports = {
   mapLastLoginValuesToDateValues,
   checkClientId,
   _unescape,
+  getReturnOrgId,
 };

--- a/src/app/services/utils.js
+++ b/src/app/services/utils.js
@@ -510,6 +510,14 @@ const getReturnOrgId = (requestQuery) => {
   return null;
 };
 
+const getReturnUrl = (requestQuery, url) => {
+  const returnOrgId = getReturnOrgId(requestQuery);
+  if (returnOrgId !== null) {
+    return `${url}?returnOrg=${returnOrgId}`;
+  }
+  return url;
+};
+
 module.exports = {
   mapUserToSupportModel,
   getUserDetails,
@@ -535,4 +543,5 @@ module.exports = {
   checkClientId,
   _unescape,
   getReturnOrgId,
+  getReturnUrl,
 };

--- a/src/app/services/views/associateService.ejs
+++ b/src/app/services/views/associateService.ejs
@@ -57,7 +57,7 @@
                 </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
-                <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                <a href="<%= locals.backLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
             </div>
         </form>
     </div>

--- a/src/app/services/views/audit.ejs
+++ b/src/app/services/views/audit.ejs
@@ -17,6 +17,10 @@
                 numberOfResultsOnPage: locals.audits.length,
                 data: [],
             }
+
+            if (returnOrgId) {
+                paginationModel.data.push({ key: "returnOrg", value: returnOrgId });
+            }
             %>
 
             <%- include('../../layouts/pagination', paginationModel); %>

--- a/src/app/services/views/editService.ejs
+++ b/src/app/services/views/editService.ejs
@@ -69,7 +69,7 @@
 
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Save</button>
-                <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
+                <a href="<%= locals.backLink %>" class="govuk-button govuk-button--secondary">Cancel</a>
             </div>
 
         </form>
@@ -83,7 +83,7 @@
             <h2 class="govuk-heading-m">Related actions</h2>
             <ul class="govuk-list">
                 <li>
-                    <a class="govuk-link-bold" href="<%= locals.organisation.id %>/remove-service">Remove service</a>
+                    <a class="govuk-link-bold" href="<%= locals.organisation.id %>/remove-service<%= locals.returnOrgId ? `?returnOrg=${locals.returnOrgId}` : '' %>">Remove service</a>
                 </li>
             </ul>
         </aside>

--- a/src/app/services/views/organisationUserList.ejs
+++ b/src/app/services/views/organisationUserList.ejs
@@ -97,7 +97,7 @@
                                 <% } else {%> 
                                 <a 
                                     class="govuk-link breakable"
-                                    href="/services/<%= locals.serviceId %>/users/<%= users[i].id %>/organisations/<%=locals.organisation.id%>/userDetails">
+                                    href="/services/<%= locals.serviceId %>/users/<%= users[i].id %>/organisations/?returnOrg=<%=locals.organisation.id%>">
                                     <%= user.firstName %> <%= user.lastName %>
                                 </a>
                                 <%}%>

--- a/src/app/services/views/summaryPartial.ejs
+++ b/src/app/services/views/summaryPartial.ejs
@@ -80,9 +80,9 @@
             <ul class="govuk-list">
                 <li>
                 <% if (area==='audit' ) { %>
-                    <a id="change-service" class="govuk-link-bold" href="/services/<%= locals.serviceId %>/users/<%=user.id%>/organisations">View user details</a>
+                    <a id="change-service" class="govuk-link-bold" href="/services/<%= locals.serviceId %>/users/<%=user.id%>/organisations<%= locals.returnOrgId ? `?returnOrg=${locals.returnOrgId}` : '' %>">View user details</a>
                 <% } else { %>
-                    <a id="change-service" class="govuk-link-bold" href="/services/<%= locals.serviceId %>/users/<%=user.id%>/audit">View user sign in audit</a>
+                    <a id="change-service" class="govuk-link-bold" href="/services/<%= locals.serviceId %>/users/<%=user.id%>/audit<%= locals.returnOrgId ? `?returnOrg=${locals.returnOrgId}` : '' %>">View user sign in audit</a>
                 <% } %>
                 </li>
             </ul>

--- a/src/app/services/views/userOrganisations.ejs
+++ b/src/app/services/views/userOrganisations.ejs
@@ -42,11 +42,7 @@
 						org.services.some(s => s.id === currentService.id); %> <% if
 						(!isOrgAssociatdWithCurrentService && (user.status.id !== -2 && user.status.id !== 0)) { %>
 						<dt class="govuk-label">
-							<% if(locals.currentOrgId === undefined) {%>
-								<a class ="govuk-link" href="/services/<%= locals.serviceId%>/users/<%=user.id %>/organisations/<%=org.id%>/associate-service">Give access to service</a>
-								<%} else {%>
-							<a class ="govuk-link" href="/services/<%= locals.serviceId%>/users/<%=user.id %>/organisations/<%=org.id%>/<%=locals.currentOrgId%>/associate-service">Give access to service</a>
-							<% }%>
+							<a class="govuk-link" href="/services/<%= serviceId %>/users/<%= user.id %>/organisations/<%= org.id %>/associate-service<%= returnOrgId ? `?returnOrg=${returnOrgId}` : '' %>">Give access to service</a>
 						</dt>
 						<% }%>
 						<article class="organisation-services" style="margin-bottom: 0">
@@ -129,15 +125,11 @@
 							%> <% const service = org.services[i];%>
 							<tr class="govuk-table__row">
 								<td class="govuk-table__cell">
-								
-										<span
-											class="govuk-!-font-weight-bold"
-										>
-											<%=service.name%>
-										<% if (service.id === currentService.id && (user.status.id !== -2 && user.status.id !== 0)) { %>
-								<div>
-									<a href="organisations/<%=org.id%>" class="govuk-link govuk-!-font-weight-bold">Edit service</a>
-								</div>
+									<span class="govuk-!-font-weight-bold"><%=service.name%></span>
+									<% if (service.id === currentService.id && (user.status.id !== -2 && user.status.id !== 0)) { %>
+									<div>
+										<a href="/services/<%= serviceId %>/users/<%= user.id %>/organisations/<%= org.id %><%= returnOrgId ? `?returnOrg=${returnOrgId}` : '' %>" class="govuk-link govuk-!-font-weight-bold">Edit service</a>
+									</div>
 									<% }%>
 								</td>
 								<% if (service.serviceRoles.length > 0) { %>

--- a/test/app/services/associateService.get.test.js
+++ b/test/app/services/associateService.get.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("login.dfe.policy-engine");
 jest.mock("../../../src/infrastructure/organisations");

--- a/test/app/services/associateService.get.test.js
+++ b/test/app/services/associateService.get.test.js
@@ -1,23 +1,25 @@
-jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
-jest.mock('login.dfe.policy-engine');
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('../../../src/infrastructure/applications', () => ({
+/* eslint-disable global-require */
+jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("login.dfe.policy-engine");
+jest.mock("../../../src/infrastructure/organisations");
+jest.mock("../../../src/infrastructure/applications", () => ({
   getServiceById: jest.fn(),
 }));
 
-const PolicyEngine = require('login.dfe.policy-engine');
-const { getRequestMock, getResponseMock } = require('../../utils');
-const { getUserDetails } = require('../../../src/app/services/utils');
-const { getOrganisationByIdV2 } = require('../../../src/infrastructure/organisations');
-const { getServiceById } = require('../../../src/infrastructure/applications');
+const PolicyEngine = require("login.dfe.policy-engine");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getServiceById } = require("../../../src/infrastructure/applications");
 
 const policyEngine = {
   getPolicyApplicationResultsForUser: jest.fn(),
   validate: jest.fn(),
 };
-describe('when displaying the associate service view', () => {
+describe("when displaying the associate service view", () => {
   let req;
   let res;
 
@@ -26,102 +28,130 @@ describe('when displaying the associate service view', () => {
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
-      name: 'John Doe',
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'johndoe@test.gov.uk',
+      id: "user1",
+      name: "John Doe",
+      firstName: "John",
+      lastName: "Doe",
+      email: "johndoe@test.gov.uk",
     });
 
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org1',
-      name: 'Organisation One',
+      id: "org1",
+      name: "Organisation One",
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'Service One',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "Service One",
     });
 
     res = getResponseMock();
 
     policyEngine.getPolicyApplicationResultsForUser.mockReset().mockReturnValue({
-      rolesAvailableToUser: ['role1', 'role2'],
+      rolesAvailableToUser: ["role1", "role2"],
     });
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
-    getAssociateService = require('../../../src/app/services/associateService').get;
+    // Require needed on beforeEach as Policy Engine is instantiated outside of route action.
+    // eslint-disable-next-line global-require
+    getAssociateService = require("../../../src/app/services/associateService").get;
   });
 
-  it('then it should get the user details', async () => {
+  it("then it should get the user details", async () => {
     await getAssociateService(req, res);
     expect(getUserDetails.mock.calls).toHaveLength(1);
   });
 
-  it('then it should get the service details by id', async () => {
+  it("then it should get the service details by id", async () => {
     await getAssociateService(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(1);
-    expect(getServiceById.mock.calls[0][0]).toBe('service1');
+    expect(getServiceById.mock.calls[0][0]).toBe("service1");
   });
 
-  it('then it should get the org details', async () => {
+  it("then it should get the org details", async () => {
     await getAssociateService(req, res);
 
     expect(getOrganisationByIdV2.mock.calls).toHaveLength(1);
-    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe('org1');
-    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe('correlationId');
+    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe("org1");
+    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should return the associate service view', async () => {
+  it("then it should return the associate service view", async () => {
     await getAssociateService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/associateService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/associateService");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include the user details', async () => {
+  it("then it should include the user details", async () => {
     await getAssociateService(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      user: { id: 'user1', email: 'johndoe@test.gov.uk', name: 'John Doe' },
+      user: { id: "user1", email: "johndoe@test.gov.uk", name: "John Doe" },
     });
   });
 
-  it('then it should include the organisation details', async () => {
+  it("then it should include the organisation details", async () => {
     await getAssociateService(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      organisation: { id: 'org1', name: 'Organisation One' },
+      organisation: { id: "org1", name: "Organisation One" },
     });
   });
 
-  it('then it should include the service details', async () => {
+  it("then it should include the service details", async () => {
     await getAssociateService(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      service: { id: 'service1', name: 'Service One' },
+      service: { id: "service1", name: "Service One" },
     });
   });
-  it('then it should include the roles available to the user', async () => {
+
+  it("then it should include the roles available to the user", async () => {
     await getAssociateService(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      serviceRoles: ['role1', 'role2'],
+      serviceRoles: ["role1", "role2"],
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
     });
   });
 });

--- a/test/app/services/associateService.post.test.js
+++ b/test/app/services/associateService.post.test.js
@@ -1,18 +1,20 @@
-jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
-jest.mock('./../../../src/app/services/utils');
-jest.mock('login.dfe.policy-engine');
-jest.mock('../../../src/infrastructure/applications');
+/* eslint-disable global-require */
+jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("login.dfe.policy-engine");
+jest.mock("../../../src/infrastructure/applications");
 
-const PolicyEngine = require('login.dfe.policy-engine');
-const { getRequestMock, getResponseMock } = require('../../utils');
-const { getServiceById } = require('../../../src/infrastructure/applications');
+const PolicyEngine = require("login.dfe.policy-engine");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getServiceById } = require("../../../src/infrastructure/applications");
 
 const policyEngine = {
   getPolicyApplicationResultsForUser: jest.fn(),
   validate: jest.fn(),
 };
-describe('when associating a service with user', () => {
+describe("when associating a service with user", () => {
   let req;
   let res;
 
@@ -21,45 +23,94 @@ describe('when associating a service with user', () => {
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      name: 'Service One',
+      id: "service1",
+      name: "Service One",
     });
 
     res = getResponseMock();
 
     policyEngine.getPolicyApplicationResultsForUser.mockReset().mockReturnValue({
-      rolesAvailableToUser: ['role1', 'role2'],
+      rolesAvailableToUser: ["role1", "role2"],
     });
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
-    postAssociateService = require('../../../src/app/services/associateService').post;
+    // Require needed on beforeEach as Policy Engine is instantiated outside of route action.
+    // eslint-disable-next-line global-require
+    postAssociateService = require("../../../src/app/services/associateService").post;
   });
-  it('then it should render a view with error if selection is not valid', async () => {
-    policyEngine.validate.mockReturnValue([{ message: 'selections not valid' }]);
+
+  it("then it should render a view with error if selection is not valid", async () => {
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
 
     await postAssociateService(req, res);
 
     expect(res.redirect.mock.calls).toHaveLength(0);
     expect(res.render.mock.calls).toHaveLength(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/associateService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/associateService");
     expect(res.render.mock.calls[0][1]).toMatchObject({
       validationMessages: {
-        roles: ['selections not valid'],
+        roles: ["selections not valid"],
       },
     });
   });
 
-  it('then it should redirect to confirm details if selection is valid', async () => {
+  it("then it should include a back link to the user's organisation list without a query string, if a returnOrg ID isn't set and there validation errors", async () => {
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    req.query.returnOrg = undefined;
+    await postAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if a returnOrg ID is invalid and there validation errors", async () => {
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    req.query.returnOrg = "foo";
+    await postAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list with a returnOrg query string, if a returnOrg ID is valid and there are validation errors", async () => {
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await postAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
+    });
+  });
+
+  it("then it should redirect to confirm details without a returnOrg query string, if selection is valid and the returnOrg ID is not set", async () => {
     policyEngine.validate.mockReturnValue([]);
+    req.query.returnOrg = undefined;
     await postAssociateService(req, res);
     expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe('confirm-associate-service');
+    expect(res.redirect.mock.calls[0][0]).toBe("confirm-associate-service");
+  });
+
+  it("then it should redirect to confirm details without a returnOrg query string, if selection is valid and the returnOrg ID is invalid", async () => {
+    policyEngine.validate.mockReturnValue([]);
+    req.query.returnOrg = "foo";
+    await postAssociateService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe("confirm-associate-service");
+  });
+
+  it("then it should redirect to confirm details with a returnOrg query string, if selection is valid and the returnOrg ID is valid", async () => {
+    policyEngine.validate.mockReturnValue([]);
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await postAssociateService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`confirm-associate-service?returnOrg=${orgId}`);
   });
 });

--- a/test/app/services/associateService.post.test.js
+++ b/test/app/services/associateService.post.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("login.dfe.policy-engine");
 jest.mock("../../../src/infrastructure/applications");

--- a/test/app/services/confirmAssociateService.get.test.js
+++ b/test/app/services/confirmAssociateService.get.test.js
@@ -1,161 +1,193 @@
-jest.mock('../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
-jest.mock('../../../src/app/services/utils');
-jest.mock('../../../src/infrastructure/access', () => ({
+/* eslint-disable global-require */
+jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("../../../src/infrastructure/access", () => ({
   listRolesOfService: jest.fn(),
 }));
-jest.mock('../../../src/infrastructure/applications', () => ({
+jest.mock("../../../src/infrastructure/applications", () => ({
   getServiceById: jest.fn(),
 }));
-jest.mock('../../../src/infrastructure/organisations', () => ({
+jest.mock("../../../src/infrastructure/organisations", () => ({
   getOrganisationByIdV2: jest.fn(),
 }));
 
-const { getRequestMock, getResponseMock } = require('../../utils');
-const { listRolesOfService } = require('../../../src/infrastructure/access');
-const { getOrganisationByIdV2 } = require('../../../src/infrastructure/organisations');
-const { getUserDetails } = require('../../../src/app/services/utils');
-const { getServiceById } = require('../../../src/infrastructure/applications');
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { listRolesOfService } = require("../../../src/infrastructure/access");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const getConfirmAssociateService = require("../../../src/app/services/confirmAssociateService").get;
 
 const res = getResponseMock();
 
-describe('when displaying the confirm associate service view', () => {
+describe("when displaying the confirm associate service view", () => {
   let req;
-
-  let getConfirmAssociateService;
 
   beforeEach(() => {
     req = getRequestMock({
       params: {
-        uid: 'user1',
-        oid: 'org1',
-        sid: 'service1',
+        uid: "user1",
+        oid: "org1",
+        sid: "service1",
       },
       session: {
         service: {
-          roles: ['role_id'],
+          roles: ["role_id"],
         },
       },
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     listRolesOfService.mockReset();
-    listRolesOfService.mockReturnValue([{
-      code: 'role_code',
-      id: 'role_id',
-      name: 'role_name',
-      status: {
-        id: 'status_id',
+    listRolesOfService.mockReturnValue([
+      {
+        code: "role_code",
+        id: "role_id",
+        name: "role_name",
+        status: {
+          id: "status_id",
+        },
       },
-    }]);
+    ]);
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
-      name: 'John Doe',
+      id: "user1",
+      name: "John Doe",
     });
 
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org1',
-      name: 'org name',
+      id: "org1",
+      name: "org name",
     });
-    getConfirmAssociateService = require('../../../src/app/services/confirmAssociateService').get;
   });
 
-  it('then it should get the service details by id', async () => {
+  it("then it should get the service details by id", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(1);
-    expect(getServiceById.mock.calls[0][0]).toBe('service1');
-    expect(getServiceById.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceById.mock.calls[0][0]).toBe("service1");
+    expect(getServiceById.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the selected roles details', async () => {
+  it("then it should get the selected roles details", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(listRolesOfService.mock.calls).toHaveLength(1);
-    expect(listRolesOfService.mock.calls[0][0]).toBe('service1');
-    expect(listRolesOfService.mock.calls[0][1]).toBe('correlationId');
+    expect(listRolesOfService.mock.calls[0][0]).toBe("service1");
+    expect(listRolesOfService.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the org details', async () => {
+  it("then it should get the org details", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(getOrganisationByIdV2.mock.calls).toHaveLength(1);
-    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe('org1');
-    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe('correlationId');
+    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe("org1");
+    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should return the confirm associate services view', async () => {
+  it("then it should return the confirm associate services view", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/confirmAssociateService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/confirmAssociateService");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include the user details', async () => {
+  it("then it should include the user details", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       user: {
-        id: 'user1',
-        name: 'John Doe',
+        id: "user1",
+        name: "John Doe",
       },
     });
   });
 
-  it('then it should include the organisation details', async () => {
+  it("then it should include the organisation details", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       organisation: {
-        id: 'org1',
-        name: 'org name',
+        id: "org1",
+        name: "org name",
       },
     });
   });
 
-  it('then it should include the service details', async () => {
+  it("then it should include the service details", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       service: {
-        id: 'service1',
-        dateActivated: '10/10/2018',
-        name: 'service name',
-        status: 'active',
+        id: "service1",
+        dateActivated: "10/10/2018",
+        name: "service name",
+        status: "active",
       },
     });
   });
 
-  it('then it should include the roles', async () => {
+  it("then it should include the roles", async () => {
     await getConfirmAssociateService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      roles: [{
-        code: 'role_code',
-        id: 'role_id',
-        name: 'role_name',
-        status: {
-          id: 'status_id',
+      roles: [
+        {
+          code: "role_code",
+          id: "role_id",
+          name: "role_name",
+          status: {
+            id: "status_id",
+          },
         },
-      }],
+      ],
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getConfirmAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}/associate-service`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getConfirmAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}/associate-service`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getConfirmAssociateService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}/associate-service?returnOrg=${orgId}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
     });
   });
 });

--- a/test/app/services/confirmAssociateService.get.test.js
+++ b/test/app/services/confirmAssociateService.get.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("../../../src/infrastructure/access", () => ({
   listRolesOfService: jest.fn(),

--- a/test/app/services/confirmAssociateService.post.test.js
+++ b/test/app/services/confirmAssociateService.post.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/access", () => ({
   addUserService: jest.fn(),

--- a/test/app/services/confirmEditService.get.test.js
+++ b/test/app/services/confirmEditService.get.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/access", () => ({
   listRolesOfService: jest.fn(),

--- a/test/app/services/confirmEditService.get.test.js
+++ b/test/app/services/confirmEditService.get.test.js
@@ -1,155 +1,181 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/access', () => {
-  return {
-    listRolesOfService: jest.fn(),
-  };
-});
-jest.mock('./../../../src/infrastructure/applications', () => {
-  return {
-    getServiceById: jest.fn(),
-  };
-});
-jest.mock('./../../../src/infrastructure/organisations', () => {
-  return {
-    getOrganisationByIdV2: jest.fn(),
-  };
-});
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/access", () => ({
+  listRolesOfService: jest.fn(),
+}));
+jest.mock("./../../../src/infrastructure/applications", () => ({
+  getServiceById: jest.fn(),
+}));
+jest.mock("./../../../src/infrastructure/organisations", () => ({
+  getOrganisationByIdV2: jest.fn(),
+}));
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const { listRolesOfService } = require('./../../../src/infrastructure/access');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
-const { getUserDetails } = require('./../../../src/app/services/utils');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { listRolesOfService } = require("../../../src/infrastructure/access");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const getConfirmEditService = require("../../../src/app/services/confirmEditService").get;
+
 const res = getResponseMock();
 
-describe('when displaying the confirm edit service view', () => {
-
+describe("when displaying the confirm edit service view", () => {
   let req;
-
-  let getConfirmEditService;
 
   beforeEach(() => {
     req = getRequestMock({
       params: {
-        uid: 'user1',
-        oid: 'org1',
-        sid: 'service1',
+        uid: "user1",
+        oid: "org1",
+        sid: "service1",
       },
       session: {
         service: {
-          roles: ['role_id']
+          roles: ["role_id"],
         },
       },
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     listRolesOfService.mockReset();
-    listRolesOfService.mockReturnValue([{
-      code: 'role_code',
-      id: 'role_id',
-      name: 'role_name',
-      status: {
-        id: 'status_id'
+    listRolesOfService.mockReturnValue([
+      {
+        code: "role_code",
+        id: "role_id",
+        name: "role_name",
+        status: {
+          id: "status_id",
+        },
       },
-    }]);
+    ]);
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
 
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org1',
-      name: 'org name',
+      id: "org1",
+      name: "org name",
     });
-    getConfirmEditService = require('./../../../src/app/services/confirmEditService').get;
   });
 
-  it('then it should get the service details by id', async () => {
+  it("then it should get the service details by id", async () => {
     await getConfirmEditService(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(1);
-    expect(getServiceById.mock.calls[0][0]).toBe('service1');
-    expect(getServiceById.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceById.mock.calls[0][0]).toBe("service1");
+    expect(getServiceById.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the selected roles details', async () => {
+  it("then it should get the selected roles details", async () => {
     await getConfirmEditService(req, res);
 
     expect(listRolesOfService.mock.calls).toHaveLength(1);
-    expect(listRolesOfService.mock.calls[0][0]).toBe('service1');
-    expect(listRolesOfService.mock.calls[0][1]).toBe('correlationId');
+    expect(listRolesOfService.mock.calls[0][0]).toBe("service1");
+    expect(listRolesOfService.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the org details', async () => {
+  it("then it should get the org details", async () => {
     await getConfirmEditService(req, res);
 
     expect(getOrganisationByIdV2.mock.calls).toHaveLength(1);
-    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe('org1');
-    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe('correlationId');
+    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe("org1");
+    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should return the confirm edit services view', async () => {
+  it("then it should return the confirm edit services view", async () => {
     await getConfirmEditService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/confirmEditService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/confirmEditService");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getConfirmEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include the organisation details', async () => {
+  it("then it should include the organisation details", async () => {
     await getConfirmEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       organisation: {
-        id: 'org1',
-        name: 'org name',
+        id: "org1",
+        name: "org name",
       },
     });
   });
 
-  it('then it should include the service details', async () => {
+  it("then it should include the service details", async () => {
     await getConfirmEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       service: {
-        id: 'service1',
-        dateActivated: '10/10/2018',
-        name: 'service name',
-        status: 'active',
+        id: "service1",
+        dateActivated: "10/10/2018",
+        name: "service name",
+        status: "active",
       },
     });
   });
 
-  it('then it should include the roles', async () => {
+  it("then it should include the roles", async () => {
     await getConfirmEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      roles: [{
-        code: 'role_code',
-        id: 'role_id',
-        name: 'role_name',
-        status: {
-          id: 'status_id',
+      roles: [
+        {
+          code: "role_code",
+          id: "role_id",
+          name: "role_name",
+          status: {
+            id: "status_id",
+          },
         },
-      }],
+      ],
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getConfirmEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getConfirmEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getConfirmEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}?returnOrg=${orgId}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
     });
   });
 });

--- a/test/app/services/confirmEditService.post.test.js
+++ b/test/app/services/confirmEditService.post.test.js
@@ -1,153 +1,161 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/access', () => {
-  return {
-    updateUserService: jest.fn(),
-    updateInvitationService: jest.fn(),
-    listRolesOfService: jest.fn(),
-  };
-});
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/access", () => ({
+  updateUserService: jest.fn(),
+  updateInvitationService: jest.fn(),
+  listRolesOfService: jest.fn(),
+}));
 
-jest.mock('./../../../src/infrastructure/applications', () => {
-  return {
-    getServiceById: jest.fn(),
-  };
-});
-jest.mock('./../../../src/infrastructure/organisations', () => {
-  return {
-    getOrganisationByIdV2: jest.fn(),
-  };
-});
+jest.mock("./../../../src/infrastructure/applications", () => ({
+  getServiceById: jest.fn(),
+}));
+jest.mock("./../../../src/infrastructure/organisations", () => ({
+  getOrganisationByIdV2: jest.fn(),
+}));
 
-const logger = require('./../../../src/infrastructure/logger');
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const { updateInvitationService, updateUserService } = require('./../../../src/infrastructure/access');
-const { listRolesOfService } = require('./../../../src/infrastructure/access');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
-const { getUserDetails } = require('./../../../src/app/services/utils');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
+const logger = require("../../../src/infrastructure/logger");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { updateInvitationService, updateUserService } = require("../../../src/infrastructure/access");
+const { listRolesOfService } = require("../../../src/infrastructure/access");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const postConfirmEditService = require("../../../src/app/services/confirmEditService").post;
+
 const res = getResponseMock();
 
-describe('when editing a service for a user', () => {
-
+describe("when editing a service for a user", () => {
   let req;
-
-  let postConfirmEditService;
 
   beforeEach(() => {
     req = getRequestMock({
       params: {
-        uid: 'user1',
-        oid: 'org1',
-        sid: 'service1',
+        uid: "user1",
+        oid: "org1",
+        sid: "service1",
       },
       session: {
         service: {
-          roles: ['role_id']
+          roles: ["role_id"],
         },
       },
     });
 
-
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     listRolesOfService.mockReset();
-    listRolesOfService.mockReturnValue([{
-      code: 'role_code',
-      id: 'role_id',
-      name: 'role_name',
-      status: {
-        id: 'status_id'
+    listRolesOfService.mockReturnValue([
+      {
+        code: "role_code",
+        id: "role_id",
+        name: "role_name",
+        status: {
+          id: "status_id",
+        },
       },
-    }]);
+    ]);
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
 
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org1',
-      name: 'org name',
+      id: "org1",
+      name: "org name",
     });
 
     updateUserService.mockReset();
     updateInvitationService.mockReset();
 
     res.mockResetAll();
-
-    postConfirmEditService = require('./../../../src/app/services/confirmEditService').post;
   });
 
-  it('then it should edit service for invitation if request for invitation', async () => {
-    req.params.uid = 'inv-invite1';
+  it("then it should edit service for invitation if request for invitation", async () => {
+    req.params.uid = "inv-invite1";
 
     await postConfirmEditService(req, res);
 
     expect(updateInvitationService.mock.calls).toHaveLength(1);
-    expect(updateInvitationService.mock.calls[0][0]).toBe('invite1');
-    expect(updateInvitationService.mock.calls[0][1]).toBe('service1');
-    expect(updateInvitationService.mock.calls[0][2]).toBe('org1');
+    expect(updateInvitationService.mock.calls[0][0]).toBe("invite1");
+    expect(updateInvitationService.mock.calls[0][1]).toBe("service1");
+    expect(updateInvitationService.mock.calls[0][2]).toBe("org1");
     expect(updateInvitationService.mock.calls[0][3]).toEqual(["role_id"]);
-    expect(updateInvitationService.mock.calls[0][4]).toBe('correlationId');
+    expect(updateInvitationService.mock.calls[0][4]).toBe("correlationId");
   });
 
-  it('then it should edit service for user if request for user', async () => {
-
+  it("then it should edit service for user if request for user", async () => {
     await postConfirmEditService(req, res);
 
     expect(updateUserService.mock.calls).toHaveLength(1);
-    expect(updateUserService.mock.calls[0][0]).toBe('user1');
-    expect(updateUserService.mock.calls[0][1]).toBe('service1');
-    expect(updateUserService.mock.calls[0][2]).toBe('org1');
+    expect(updateUserService.mock.calls[0][0]).toBe("user1");
+    expect(updateUserService.mock.calls[0][1]).toBe("service1");
+    expect(updateUserService.mock.calls[0][2]).toBe("org1");
     expect(updateUserService.mock.calls[0][3]).toEqual(["role_id"]);
-    expect(updateUserService.mock.calls[0][4]).toBe('correlationId');
+    expect(updateUserService.mock.calls[0][4]).toBe("correlationId");
   });
 
-  it('then it should should audit service being edited', async () => {
+  it("then it should should audit service being edited", async () => {
     await postConfirmEditService(req, res);
 
     expect(logger.audit.mock.calls).toHaveLength(1);
-    expect(logger.audit.mock.calls[0][0]).toBe('user@unit.test (id: user1) updated service service name for organisation org name (id: org1) for user undefined (id: user1)');
+    expect(logger.audit.mock.calls[0][0]).toBe("user@unit.test (id: user1) updated service service name for organisation org name (id: org1) for user undefined (id: user1)");
     expect(logger.audit.mock.calls[0][1]).toMatchObject({
-      type: 'manage',
-      subType: 'user-service-updated',
-      userId: 'user1',
-      userEmail: 'user@unit.test',
-      editedUser: 'user1',
+      type: "manage",
+      subType: "user-service-updated",
+      userId: "user1",
+      userEmail: "user@unit.test",
+      editedUser: "user1",
       editedFields: [
         {
-          name: 'update_service',
-          newValue: ['role_id'],
-        }
+          name: "update_service",
+          newValue: ["role_id"],
+        },
       ],
     });
   });
 
-  it('then it should redirect to user details', async () => {
+  it("then a flash message is shown to the user", async () => {
     await postConfirmEditService(req, res);
 
+    expect(res.flash.mock.calls).toHaveLength(3);
+    expect(res.flash.mock.calls[0][0]).toBe("title");
+    expect(res.flash.mock.calls[0][1]).toBe("Success");
+    expect(res.flash.mock.calls[1][0]).toBe("heading");
+    expect(res.flash.mock.calls[1][1]).toBe("Service updated: service name");
+    expect(res.flash.mock.calls[2][0]).toBe("message");
+    expect(res.flash.mock.calls[2][1]).toBe("Approvers at the relevant organisation have been notified of this change.");
+  });
+
+  it("then it should redirect to user details without a returnOrg query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await postConfirmEditService(req, res);
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
   });
 
-  it('then a flash message is shown to the user', async () => {
+  it("then it should redirect to user details without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
     await postConfirmEditService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
+  });
 
-    expect(res.flash.mock.calls).toHaveLength(3);
-    expect(res.flash.mock.calls[0][0]).toBe('title');
-    expect(res.flash.mock.calls[0][1]).toBe('Success');
-    expect(res.flash.mock.calls[1][0]).toBe('heading');
-    expect(res.flash.mock.calls[1][1]).toBe('Service updated: service name');
-    expect(res.flash.mock.calls[2][0]).toBe('message');
-    expect(res.flash.mock.calls[2][1]).toBe('Approvers at the relevant organisation have been notified of this change.');
+  it("then it should redirect to user details with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await postConfirmEditService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`);
   });
 });

--- a/test/app/services/confirmEditService.post.test.js
+++ b/test/app/services/confirmEditService.post.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/access", () => ({
   updateUserService: jest.fn(),

--- a/test/app/services/editService.get.test.js
+++ b/test/app/services/editService.get.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("login.dfe.policy-engine");
 jest.mock("./../../../src/infrastructure/access");

--- a/test/app/services/editService.get.test.js
+++ b/test/app/services/editService.get.test.js
@@ -1,24 +1,25 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('login.dfe.policy-engine');
-jest.mock('./../../../src/infrastructure/access');
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('./../../../src/app/services/utils');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("login.dfe.policy-engine");
+jest.mock("./../../../src/infrastructure/access");
+jest.mock("./../../../src/infrastructure/applications");
+jest.mock("./../../../src/infrastructure/organisations");
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const PolicyEngine = require('login.dfe.policy-engine');
-const { getSingleUserService, getSingleInvitationService } = require('./../../../src/infrastructure/access');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
-const { getUserDetails } = require('./../../../src/app/services/utils');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
+const PolicyEngine = require("login.dfe.policy-engine");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getSingleUserService, getSingleInvitationService } = require("../../../src/infrastructure/access");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
 
 const policyEngine = {
   getPolicyApplicationResultsForUser: jest.fn(),
 };
 
-describe('when displaying the edit service view', () => {
-
+describe("when displaying the edit service view", () => {
   let req;
   let res;
 
@@ -27,9 +28,9 @@ describe('when displaying the edit service view', () => {
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
     res = getResponseMock();
 
@@ -40,126 +41,168 @@ describe('when displaying the edit service view', () => {
 
     getSingleUserService.mockReset();
     getSingleUserService.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     getSingleInvitationService.mockReset();
     getSingleInvitationService.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active'
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      serviceId: 'service1',
-      name: 'service one',
-      description: 'service description',
+      serviceId: "service1",
+      name: "service one",
+      description: "service description",
       relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code'
-        ],
-        response_types: [
-          'code',
-        ],
-      }
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
     });
 
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org-1',
-      name: 'organisation one'
+      id: "org-1",
+      name: "organisation one",
     });
 
-    getEditService = require('./../../../src/app/services/editService').get;
+    // Require needed on beforeEach as Policy Engine is instantiated outside of route action.
+    // eslint-disable-next-line global-require
+    getEditService = require("../../../src/app/services/editService").get;
   });
 
-  it('then it should get the selected user service if req for user', async () => {
+  it("then it should get the selected user service if req for user", async () => {
     await getEditService(req, res);
 
     expect(getSingleUserService.mock.calls).toHaveLength(1);
-    expect(getSingleUserService.mock.calls[0][0]).toBe('user1');
-    expect(getSingleUserService.mock.calls[0][1]).toBe('service1');
-    expect(getSingleUserService.mock.calls[0][2]).toBe('org1');
-    expect(getSingleUserService.mock.calls[0][3]).toBe('correlationId');
+    expect(getSingleUserService.mock.calls[0][0]).toBe("user1");
+    expect(getSingleUserService.mock.calls[0][1]).toBe("service1");
+    expect(getSingleUserService.mock.calls[0][2]).toBe("org1");
+    expect(getSingleUserService.mock.calls[0][3]).toBe("correlationId");
   });
 
-  it('then it should get the selected invitation service if req for inv', async () => {
-    req.params.uid = 'inv-user1';
+  it("then it should get the selected invitation service if req for inv", async () => {
+    req.params.uid = "inv-user1";
     await getEditService(req, res);
 
     expect(getSingleInvitationService.mock.calls).toHaveLength(1);
-    expect(getSingleInvitationService.mock.calls[0][0]).toBe('user1');
-    expect(getSingleInvitationService.mock.calls[0][1]).toBe('service1');
-    expect(getSingleInvitationService.mock.calls[0][2]).toBe('org1');
-    expect(getSingleInvitationService.mock.calls[0][3]).toBe('correlationId');
+    expect(getSingleInvitationService.mock.calls[0][0]).toBe("user1");
+    expect(getSingleInvitationService.mock.calls[0][1]).toBe("service1");
+    expect(getSingleInvitationService.mock.calls[0][2]).toBe("org1");
+    expect(getSingleInvitationService.mock.calls[0][3]).toBe("correlationId");
   });
 
-  it('then it should get user details', async () => {
+  it("then it should get user details", async () => {
     await getEditService(req, res);
 
     expect(getUserDetails.mock.calls).toHaveLength(1);
     expect(getUserDetails.mock.calls[0][0]).toBe(req);
   });
 
-  it('then it should get the org details', async () => {
+  it("then it should get the org details", async () => {
     await getEditService(req, res);
 
     expect(getOrganisationByIdV2.mock.calls).toHaveLength(1);
-    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe('org1');
-    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe('correlationId');
+    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe("org1");
+    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should return the edit service view', async () => {
+  it("then it should return the edit service view", async () => {
     await getEditService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/editService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/editService");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include the organisation details', async () => {
+  it("then it should include the organisation details", async () => {
     await getEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       organisation: {
-        id: 'org-1',
-        name: 'organisation one'
+        id: "org-1",
+        name: "organisation one",
       },
     });
   });
 
-  it('then it should include the service details', async () => {
+  it("then it should include the service details", async () => {
     await getEditService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       service: {
-        name: 'service one',
-      }
+        name: "service one",
+      },
     });
   });
 
+  it("then it should include the returnOrgId as null, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as an ID string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: orgId,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getEditService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
+    });
+  });
 });

--- a/test/app/services/editService.post.test.js
+++ b/test/app/services/editService.post.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/access");
 jest.mock("./../../../src/infrastructure/applications");

--- a/test/app/services/editService.post.test.js
+++ b/test/app/services/editService.post.test.js
@@ -1,24 +1,25 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('login.dfe.policy-engine');
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/access');
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/organisations');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/access");
+jest.mock("./../../../src/infrastructure/applications");
+jest.mock("./../../../src/infrastructure/organisations");
+jest.mock("login.dfe.policy-engine");
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const PolicyEngine = require('login.dfe.policy-engine');
-const { getSingleUserService, getSingleInvitationService } = require('./../../../src/infrastructure/access');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
+const PolicyEngine = require("login.dfe.policy-engine");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getSingleUserService, getSingleInvitationService } = require("../../../src/infrastructure/access");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
 
 const policyEngine = {
   validate: jest.fn(),
   getPolicyApplicationResultsForUser: jest.fn(),
 };
 
-describe('when selecting the roles for a service', () => {
-
+describe("when selecting the roles for a service", () => {
   let req;
   let res;
   let postEditService;
@@ -26,88 +27,161 @@ describe('when selecting the roles for a service', () => {
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
     req.body = {
-      role: [
-        'role1',
-      ]
+      role: ["role1"],
     };
     getSingleUserService.mockReset();
     getSingleUserService.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     getSingleInvitationService.mockReset();
     getSingleInvitationService.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active'
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      serviceId: 'service1',
-      name: 'service one',
-      description: 'service description',
+      serviceId: "service1",
+      name: "service one",
+      description: "service description",
       relyingParty: {
-        client_id: 'clientid',
-        client_secret: 'dewier-thrombi-confounder-mikado',
-        api_secret: 'dewier-thrombi-confounder-mikado',
-        service_home: 'https://www.servicehome.com',
-        postResetUrl: 'https://www.postreset.com',
-        redirect_uris: [
-          'https://www.redirect.com',
-        ],
-        post_logout_redirect_uris: [
-          'https://www.logout.com',
-        ],
-        grant_types: [
-          'implicit',
-          'authorization_code'
-        ],
-        response_types: [
-          'code',
-        ],
-      }
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
     });
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org-1',
-      name: 'organisation one'
+      id: "org-1",
+      name: "organisation one",
     });
 
     res = getResponseMock();
 
     policyEngine.validate.mockReset().mockReturnValue([]);
     policyEngine.getPolicyApplicationResultsForUser.mockReset().mockReturnValue({
-      rolesAvailableToUser: ['role1'],
+      rolesAvailableToUser: ["role1"],
     });
     PolicyEngine.mockReset().mockImplementation(() => policyEngine);
 
-    postEditService = require('./../../../src/app/services/editService').post;
+    // Require needed on beforeEach as Policy Engine is instantiated outside of route action.
+    // eslint-disable-next-line global-require
+    postEditService = require("../../../src/app/services/editService").post;
   });
 
-  it('then it should render view with error if selection do not meet requirements of service', async () => {
-    policyEngine.validate.mockReturnValue([{ message: 'selections not valid' }]);
+  it("then it should render view with error if selection do not meet requirements of service", async () => {
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
 
     await postEditService(req, res);
 
     expect(res.render.mock.calls).toHaveLength(1);
-    expect(res.render.mock.calls[0][0]).toBe(`services/views/editService`);
-
+    expect(res.render.mock.calls[0][0]).toBe("services/views/editService");
   });
 
-  it('then it should redirect to confirm page if roles valid', async () => {
+  it("then it should include the returnOrgId as null, if the returnOrg ID isn't set and role selection doesn't meet requirements", async () => {
+    req.query.returnOrg = undefined;
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID is invalid and role selection doesn't meet requirements", async () => {
+    req.query.returnOrg = "foo";
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as an ID string, if the returnOrg ID is valid and role selection doesn't meet requirements", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: orgId,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID isn't set and role selection doesn't meet requirements", async () => {
+    req.query.returnOrg = undefined;
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID is invalid and role selection doesn't meet requirements", async () => {
+    req.query.returnOrg = "foo";
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list with a returnOrg query string, if the returnOrg ID is valid and role selection doesn't meet requirements", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    policyEngine.validate.mockReturnValue([{ message: "selections not valid" }]);
+    await postEditService(req, res);
+
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
+    });
+  });
+
+  it("then it should redirect to confirm details without a returnOrg query string, if role selection is valid and the returnOrg ID is not set", async () => {
+    req.query.returnOrg = undefined;
+    policyEngine.validate.mockReturnValue([]);
     await postEditService(req, res);
 
     expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`org1/confirm-edit-service`);
+    expect(res.redirect.mock.calls[0][0]).toBe(`${req.params.oid}/confirm-edit-service`);
+  });
+
+  it("then it should redirect to confirm details without a returnOrg query string, if role selection is valid and the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    policyEngine.validate.mockReturnValue([]);
+    await postEditService(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`${req.params.oid}/confirm-edit-service`);
+  });
+
+  it("then it should redirect to confirm details with a returnOrg query string, if role selection is valid and the returnOrg ID is set and valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    policyEngine.validate.mockReturnValue([]);
+    await postEditService(req, res);
+
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`${req.params.oid}/confirm-edit-service?returnOrg=${orgId}`);
   });
 });

--- a/test/app/services/getAudit.test.js
+++ b/test/app/services/getAudit.test.js
@@ -1,33 +1,35 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/utils');
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/serviceMapping');
-jest.mock('./../../../src/infrastructure/audit');
-jest.mock('ioredis');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-emable global-require */
+jest.mock("./../../../src/infrastructure/utils");
+jest.mock("./../../../src/infrastructure/organisations");
+jest.mock("./../../../src/infrastructure/applications");
+jest.mock("./../../../src/infrastructure/serviceMapping");
+jest.mock("./../../../src/infrastructure/audit");
+jest.mock("ioredis");
 
-const { getUserDetails, getUserDetailsById } = require('./../../../src/app/services/utils');
-const { getPageOfUserAudits, getUserChangeHistory } = require('./../../../src/infrastructure/audit');
-const {getServiceIdForClientId} = require('./../../../src/infrastructure/serviceMapping');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
-const getAudit = require('./../../../src/app/services/getAudit');
+const { getUserDetails, getUserDetailsById } = require("../../../src/app/services/utils");
+const { getPageOfUserAudits, getUserChangeHistory } = require("../../../src/infrastructure/audit");
+const { getServiceIdForClientId } = require("../../../src/infrastructure/serviceMapping");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const getAudit = require("../../../src/app/services/getAudit");
 
-describe('when getting users audit details', () => {
+describe("when getting users audit details", () => {
   let req;
   let res;
 
   beforeEach(() => {
     req = {
-      id: 'correlationId',
-      csrfToken: () => 'token',
-      accepts: () => ['text/html'],
+      id: "correlationId",
+      csrfToken: () => "token",
+      accepts: () => ["text/html"],
       query: {
         page: 3,
       },
       params: {
-        uid: 'user1',
-        sid: 'service-1'
+        uid: "user1",
+        sid: "service-1",
       },
     };
 
@@ -41,11 +43,11 @@ describe('when getting users audit details', () => {
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
     getUserDetailsById.mockReset();
     getUserDetailsById.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
 
     res.render.mockReset();
@@ -54,36 +56,36 @@ describe('when getting users audit details', () => {
     getPageOfUserAudits.mockReturnValue({
       audits: [
         {
-          type: 'sign-in',
-          subType: 'digipass',
+          type: "sign-in",
+          subType: "digipass",
           success: false,
-          userId: 'user1',
-          userEmail: 'some.user@test.tester',
-          level: 'audit',
-          message: 'Successful login attempt for some.user@test.tester (id: user1)',
-          timestamp: '2018-01-30T10:31:00.000Z',
-          client: 'client-1'
+          userId: "user1",
+          userEmail: "some.user@test.tester",
+          level: "audit",
+          message: "Successful login attempt for some.user@test.tester (id: user1)",
+          timestamp: "2018-01-30T10:31:00.000Z",
+          client: "client-1",
         },
         {
-          type: 'sign-in',
-          subType: 'username-password',
+          type: "sign-in",
+          subType: "username-password",
           success: true,
-          userId: 'user1',
-          userEmail: 'some.user@test.tester',
-          level: 'audit',
-          message: 'Successful login attempt for some.user@test.tester (id: user1)',
-          timestamp: '2018-01-30T10:30:53.987Z',
-          client: 'client-2'
+          userId: "user1",
+          userEmail: "some.user@test.tester",
+          level: "audit",
+          message: "Successful login attempt for some.user@test.tester (id: user1)",
+          timestamp: "2018-01-30T10:30:53.987Z",
+          client: "client-2",
         },
         {
-          type: 'some-new-type',
-          subType: 'some-subtype',
+          type: "some-new-type",
+          subType: "some-subtype",
           success: false,
-          userId: 'user1',
-          userEmail: 'some.user@test.tester',
-          level: 'audit',
-          message: 'Some detailed message',
-          timestamp: '2018-01-29T17:31:00.000Z'
+          userId: "user1",
+          userEmail: "some.user@test.tester",
+          level: "audit",
+          message: "Some detailed message",
+          timestamp: "2018-01-29T17:31:00.000Z",
         },
       ],
       numberOfPages: 3,
@@ -94,65 +96,63 @@ describe('when getting users audit details', () => {
     getUserChangeHistory.mockReturnValue({
       audits: [
         {
-          type: 'support',
-          subType: 'user-edit',
+          type: "support",
+          subType: "user-edit",
           success: false,
-          userId: 'user1',
-          userEmail: 'some.user@test.tester',
-          level: 'audit',
-          message: 'Some detailed message',
-          timestamp: '2018-01-29T17:31:00.000Z'
-        }
-      ]
+          userId: "user1",
+          userEmail: "some.user@test.tester",
+          level: "audit",
+          message: "Some detailed message",
+          timestamp: "2018-01-29T17:31:00.000Z",
+        },
+      ],
     });
 
     getServiceIdForClientId.mockReset();
     getServiceIdForClientId.mockImplementation((clientId) => {
-      if (clientId === 'client-1') {
-        return 'service-1';
+      if (clientId === "client-1") {
+        return "service-1";
       }
-      if (clientId === 'client-2') {
-        return 'service-2';
+      if (clientId === "client-2") {
+        return "service-2";
       }
       return null;
     });
 
     getServiceById.mockReset();
-    getServiceById.mockImplementation((serviceId, reqId) => {
-      return {
-        id: serviceId,
-        name: serviceId,
-        description: serviceId,
-      };
-    });
+    getServiceById.mockImplementation((serviceId) => ({
+      id: serviceId,
+      name: serviceId,
+      description: serviceId,
+    }));
   });
 
-  it('then it should send result using audit view', async () => {
+  it("then it should send result using audit view", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls).toHaveLength(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/audit');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/audit");
   });
 
-  it('then it should include csrf token in model', async () => {
+  it("then it should include csrf token in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include user details in model', async () => {
+  it("then it should include user details in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       user: {
-        id: 'user1'
+        id: "user1",
       },
     });
   });
 
-  it('then it should include number of pages of audits in model', async () => {
+  it("then it should include number of pages of audits in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
@@ -160,66 +160,66 @@ describe('when getting users audit details', () => {
     });
   });
 
-  it('then it should include current page of audits in model', async () => {
+  it("then it should include current page of audits in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       audits: [
         {
-          timestamp: new Date('2018-01-30T10:31:00.000Z'),
+          timestamp: new Date("2018-01-30T10:31:00.000Z"),
           event: {
-            type: 'sign-in',
-            subType: 'digipass',
-            description: 'Sign-in using a digipass key fob',
+            type: "sign-in",
+            subType: "digipass",
+            description: "Sign-in using a digipass key fob",
           },
           service: {
-            id: 'service-1',
-            name: 'service-1',
-            description: 'service-1',
+            id: "service-1",
+            name: "service-1",
+            description: "service-1",
           },
           organisation: null,
           result: false,
           user: {
-            id: 'user1'
+            id: "user1",
           },
         },
         {
-          timestamp: new Date('2018-01-30T10:30:53.987Z'),
+          timestamp: new Date("2018-01-30T10:30:53.987Z"),
           event: {
-            type: 'sign-in',
-            subType: 'username-password',
-            description: 'Sign-in using email address and password',
+            type: "sign-in",
+            subType: "username-password",
+            description: "Sign-in using email address and password",
           },
           service: {
-            id: 'service-2',
-            name: 'service-2',
-            description: 'service-2',
+            id: "service-2",
+            name: "service-2",
+            description: "service-2",
           },
           organisation: null,
           result: true,
           user: {
-            id: 'user1'
+            id: "user1",
           },
         },
         {
-          timestamp: new Date('2018-01-29T17:31:00.000Z'),
+          timestamp: new Date("2018-01-29T17:31:00.000Z"),
           event: {
-            type: 'some-new-type',
-            subType: 'some-subtype',
-            description: 'some-new-type / some-subtype',
+            type: "some-new-type",
+            subType: "some-subtype",
+            description: "some-new-type / some-subtype",
           },
           organisation: null,
           service: null,
           result: false,
           user: {
-            id: 'user1'
+            id: "user1",
           },
         },
       ],
     });
   });
 
-  it('then it should include page number in model', async () => {
+  it("then it should include page number in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
@@ -227,7 +227,7 @@ describe('when getting users audit details', () => {
     });
   });
 
-  it('then it should include total number of records in model', async () => {
+  it("then it should include total number of records in model", async () => {
     await getAudit(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
@@ -235,33 +235,33 @@ describe('when getting users audit details', () => {
     });
   });
 
-  it('then it should get user details', async () => {
+  it("then it should get user details", async () => {
     await getAudit(req, res);
 
     expect(getUserDetailsById.mock.calls).toHaveLength(1);
     expect(getUserDetailsById.mock.calls[0][0]).toBe(req.params.uid);
   });
 
-  it('then it should get page of audits using page 1 if page not specified', async () => {
+  it("then it should get page of audits using page 1 if page not specified", async () => {
     req.query.page = undefined;
 
     await getAudit(req, res);
 
     expect(getPageOfUserAudits.mock.calls).toHaveLength(1);
-    expect(getPageOfUserAudits.mock.calls[0][0]).toBe('user1');
+    expect(getPageOfUserAudits.mock.calls[0][0]).toBe("user1");
     expect(getPageOfUserAudits.mock.calls[0][1]).toBe(1);
   });
 
-  it('then it should get page of audits using page specified', async () => {
+  it("then it should get page of audits using page specified", async () => {
     await getAudit(req, res);
 
     expect(getPageOfUserAudits.mock.calls).toHaveLength(1);
-    expect(getPageOfUserAudits.mock.calls[0][0]).toBe('user1');
+    expect(getPageOfUserAudits.mock.calls[0][0]).toBe("user1");
     expect(getPageOfUserAudits.mock.calls[0][1]).toBe(3);
   });
 
-  it('then it should return 400 if specified page is not numeric', async () => {
-    req.query.page = 'not-a-number';
+  it("then it should return 400 if specified page is not numeric", async () => {
+    req.query.page = "not-a-number";
 
     await getAudit(req, res);
 
@@ -270,16 +270,66 @@ describe('when getting users audit details', () => {
     expect(res.send.mock.calls).toHaveLength(1);
   });
 
-  it('then it should get service for each audit that has client', async () => {
+  it("then it should get service for each audit that has client", async () => {
     await getAudit(req, res);
 
     expect(getServiceIdForClientId.mock.calls).toHaveLength(2);
-    expect(getServiceIdForClientId.mock.calls[0][0]).toBe('client-1');
-    expect(getServiceIdForClientId.mock.calls[1][0]).toBe('client-2');
+    expect(getServiceIdForClientId.mock.calls[0][0]).toBe("client-1");
+    expect(getServiceIdForClientId.mock.calls[1][0]).toBe("client-2");
 
     expect(getServiceById.mock.calls).toHaveLength(3);
-    expect(getServiceById.mock.calls[0][0]).toBe('service-1');
-    expect(getServiceById.mock.calls[1][0]).toBe('service-1');
-    expect(getServiceById.mock.calls[2][0]).toBe('service-2');
+    expect(getServiceById.mock.calls[0][0]).toBe("service-1");
+    expect(getServiceById.mock.calls[1][0]).toBe("service-1");
+    expect(getServiceById.mock.calls[2][0]).toBe("service-2");
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as an ID string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: orgId,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list without a query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include a back link to the user's organisation list with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getAudit(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
+    });
   });
 });

--- a/test/app/services/getAudit.test.js
+++ b/test/app/services/getAudit.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-emable global-require */
 jest.mock("./../../../src/infrastructure/utils");
 jest.mock("./../../../src/infrastructure/organisations");

--- a/test/app/services/getUserOrganisations.test.js
+++ b/test/app/services/getUserOrganisations.test.js
@@ -1,67 +1,65 @@
-jest.mock('./../../../src/infrastructure/config', () => require('../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('../../utils').loggerMockFactory());
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('./../../../src/infrastructure/directories');
-jest.mock('../../../src/infrastructure/access');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/organisations");
+jest.mock("./../../../src/infrastructure/directories");
+jest.mock("../../../src/infrastructure/access");
 
-const logger = require('../../../src/infrastructure/logger');
-const { getRequestMock, getResponseMock } = require('../../utils');
-const getUserOrganisations = require('../../../src/app/services/getUserOrganisations');
-const { getAllUserOrganisations, getInvitationOrganisations } = require('../../../src/infrastructure/organisations');
-const { getUsersByIdV2 } = require('../../../src/infrastructure/directories');
-const { getUserDetails } = require('../../../src/app/services/utils');
+const logger = require("../../../src/infrastructure/logger");
+const { getRequestMock, getResponseMock } = require("../../utils");
+const getUserOrganisations = require("../../../src/app/services/getUserOrganisations");
+const { getAllUserOrganisations, getInvitationOrganisations } = require("../../../src/infrastructure/organisations");
+const { getUsersByIdV2 } = require("../../../src/infrastructure/directories");
+const { getUserDetails } = require("../../../src/app/services/utils");
 
 const res = getResponseMock();
 
-describe('when getting users organisation details', () => {
+describe("when getting users organisation details", () => {
   let req;
 
   beforeEach(() => {
     req = getRequestMock({
       user: {
-        sub: 'user1',
-        email: 'super.user@unit.test',
+        sub: "user1",
+        email: "super.user@unit.test",
       },
       params: {
-        uid: 'user1',
-        sid: 'service1',
+        uid: "user1",
+        sid: "service1",
       },
       session: {},
     });
 
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
 
     getAllUserOrganisations.mockReset();
     getAllUserOrganisations.mockReturnValue([
       {
         organisation: {
-          id: '88a1ed39-5a98-43da-b66e-78e564ea72b0',
-          name: 'Great Big School',
+          id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+          name: "Great Big School",
         },
-        approvers: [
-          'user1',
-        ],
+        approvers: ["user1"],
         services: [
           {
-            id: 'service1',
+            id: "service1",
           },
         ],
       },
       {
         organisation: {
-          id: 'fe68a9f4-a995-4d74-aa4b-e39e0e88c15d',
-          name: 'Little Tiny School',
+          id: "fe68a9f4-a995-4d74-aa4b-e39e0e88c15d",
+          name: "Little Tiny School",
         },
-        approvers: [
-          'user1',
-        ],
+        approvers: ["user1"],
         services: [
           {
-            id: 'service1',
+            id: "service1",
           },
         ],
       },
@@ -71,111 +69,164 @@ describe('when getting users organisation details', () => {
     getInvitationOrganisations.mockReturnValue([
       {
         organisation: {
-          id: '88a1ed39-5a98-43da-b66e-78e564ea72b0',
-          name: 'Great Big School',
+          id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+          name: "Great Big School",
         },
-        approvers: [
-          'user1',
-        ],
+        approvers: ["user1"],
         services: [
           {
-            id: 'service1',
+            id: "service1",
           },
         ],
       },
       {
         organisation: {
-          id: 'fe68a9f4-a995-4d74-aa4b-e39e0e88c15d',
-          name: 'Little Tiny School',
+          id: "fe68a9f4-a995-4d74-aa4b-e39e0e88c15d",
+          name: "Little Tiny School",
         },
-        approvers: [
-          'user1',
-        ],
+        approvers: ["user1"],
         services: [
           {
-            id: 'service1',
+            id: "service1",
           },
         ],
       },
     ]);
 
     getUsersByIdV2.mockReset();
-    getUsersByIdV2.mockReturnValue(
-      [
-        {
-          sub: 'user1', given_name: 'User', family_name: 'One', email: 'user.one@unit.tests',
-        },
-        {
-          sub: 'user6', given_name: 'User', family_name: 'Six', email: 'user.six@unit.tests',
-        },
-        {
-          sub: 'user11', given_name: 'User', family_name: 'Eleven', email: 'user.eleven@unit.tests',
-        },
-      ],
-    );
+    getUsersByIdV2.mockReturnValue([
+      {
+        sub: "user1",
+        given_name: "User",
+        family_name: "One",
+        email: "user.one@unit.tests",
+      },
+      {
+        sub: "user6",
+        given_name: "User",
+        family_name: "Six",
+        email: "user.six@unit.tests",
+      },
+      {
+        sub: "user11",
+        given_name: "User",
+        family_name: "Eleven",
+        email: "user.eleven@unit.tests",
+      },
+    ]);
   });
 
-  it('then it should get user details', async () => {
+  it("then it should get user details", async () => {
     await getUserOrganisations(req, res);
 
     expect(getUserDetails.mock.calls).toHaveLength(1);
     expect(getUserDetails.mock.calls[0][0]).toBe(req);
     expect(res.render.mock.calls[0][1].user).toMatchObject({
-      id: 'user1',
+      id: "user1",
     });
   });
 
-  it('then it should get organisations mapping for user where they have the service', async () => {
+  it("then it should get organisations mapping for user where they have the service", async () => {
     await getUserOrganisations(req, res);
 
     expect(getAllUserOrganisations.mock.calls).toHaveLength(1);
-    expect(getAllUserOrganisations.mock.calls[0][0]).toBe('user1');
-    expect(getAllUserOrganisations.mock.calls[0][1]).toBe('correlationId');
+    expect(getAllUserOrganisations.mock.calls[0][0]).toBe("user1");
+    expect(getAllUserOrganisations.mock.calls[0][1]).toBe("correlationId");
 
     expect(res.render.mock.calls[0][1].organisations).toHaveLength(2);
     expect(res.render.mock.calls[0][1].organisations[0]).toMatchObject({
-      id: '88a1ed39-5a98-43da-b66e-78e564ea72b0',
-      name: 'Great Big School',
+      id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+      name: "Great Big School",
     });
     expect(res.render.mock.calls[0][1].organisations[1]).toMatchObject({
-      id: 'fe68a9f4-a995-4d74-aa4b-e39e0e88c15d',
-      name: 'Little Tiny School',
+      id: "fe68a9f4-a995-4d74-aa4b-e39e0e88c15d",
+      name: "Little Tiny School",
     });
   });
 
-  it('then it should get organisations mapping for invitation where they have the service', async () => {
+  it("then it should get organisations mapping for invitation where they have the service", async () => {
     getUserDetails.mockReturnValue({
-      id: 'inv-invitation1',
+      id: "inv-invitation1",
     });
 
     await getUserOrganisations(req, res);
 
     expect(getInvitationOrganisations.mock.calls).toHaveLength(1);
-    expect(getInvitationOrganisations.mock.calls[0][0]).toBe('invitation1');
-    expect(getInvitationOrganisations.mock.calls[0][1]).toBe('correlationId');
+    expect(getInvitationOrganisations.mock.calls[0][0]).toBe("invitation1");
+    expect(getInvitationOrganisations.mock.calls[0][1]).toBe("correlationId");
 
     expect(res.render.mock.calls[0][1].organisations).toHaveLength(2);
     expect(res.render.mock.calls[0][1].organisations[0]).toMatchObject({
-      id: '88a1ed39-5a98-43da-b66e-78e564ea72b0',
-      name: 'Great Big School',
+      id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+      name: "Great Big School",
     });
     expect(res.render.mock.calls[0][1].organisations[1]).toMatchObject({
-      id: 'fe68a9f4-a995-4d74-aa4b-e39e0e88c15d',
-      name: 'Little Tiny School',
+      id: "fe68a9f4-a995-4d74-aa4b-e39e0e88c15d",
+      name: "Little Tiny School",
     });
   });
 
-  it('then it should should audit user being viewed', async () => {
+  it("then it should should audit user being viewed", async () => {
     await getUserOrganisations(req, res);
 
     expect(logger.audit.mock.calls).toHaveLength(1);
-    expect(logger.audit.mock.calls[0][0]).toBe('super.user@unit.test (id: user1) viewed user undefined (id: user1)');
+    expect(logger.audit.mock.calls[0][0]).toBe("super.user@unit.test (id: user1) viewed user undefined (id: user1)");
     expect(logger.audit.mock.calls[0][1]).toMatchObject({
-      type: 'organisations',
-      subType: 'user-view',
-      userEmail: 'super.user@unit.test',
-      userId: 'user1',
-      viewedUser: 'user1',
+      type: "organisations",
+      subType: "user-view",
+      userEmail: "super.user@unit.test",
+      userId: "user1",
+      viewedUser: "user1",
+    });
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as null, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: null,
+    });
+  });
+
+  it("then it should include the returnOrgId as an ID string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      returnOrgId: orgId,
+    });
+  });
+
+  it("then it should include a back link to the user management tab, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users`,
+    });
+  });
+
+  it("then it should include a back link to the user management tab, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users`,
+    });
+  });
+
+  it("then it should include a back link to the organisation's user list, if a returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getUserOrganisations(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/organisations/${orgId}/users`,
     });
   });
 });

--- a/test/app/services/postUpdateAuditLog.test.js
+++ b/test/app/services/postUpdateAuditLog.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("../../../src/infrastructure/audit", () => ({
   api: {

--- a/test/app/services/postUpdateAuditLog.test.js
+++ b/test/app/services/postUpdateAuditLog.test.js
@@ -1,0 +1,51 @@
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("../../../src/infrastructure/audit", () => ({
+  api: {
+    updateAuditLogs: jest.fn(),
+  },
+}));
+
+const { updateAuditLogs } = require("../../../src/infrastructure/audit").api;
+const { getRequestMock, getResponseMock } = require("../../utils");
+const postUpdateAuditLog = require("../../../src/app/services/postUpdateAuditLog");
+
+describe("When requesting to update a user's audit log", () => {
+  let req;
+  const res = getResponseMock();
+
+  beforeEach(() => {
+    updateAuditLogs.mockReset();
+    req = getRequestMock();
+    res.mockResetAll();
+  });
+
+  it("calls the audit API updateAuditLogs method", async () => {
+    await postUpdateAuditLog(req, res);
+    expect(updateAuditLogs).toHaveBeenCalled();
+  });
+
+  it("should redirect to the user's audit list without a returnOrg query string, if the returnOrg ID is not set", async () => {
+    req.query.returnOrg = undefined;
+    await postUpdateAuditLog(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/audit`);
+  });
+
+  it("should redirect to the user's audit list without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await postUpdateAuditLog(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/audit`);
+  });
+
+  it("should redirect to the user's audit list with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await postUpdateAuditLog(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/audit?returnOrg=${orgId}`);
+  });
+});

--- a/test/app/services/removeService.get.test.js
+++ b/test/app/services/removeService.get.test.js
@@ -1,99 +1,129 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('./../../../src/app/services/utils');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/applications");
+jest.mock("./../../../src/infrastructure/organisations");
+jest.mock("./../../../src/app/services/utils");
 
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const { getUserDetails } = require('./../../../src/app/services/utils');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const getRemoveService = require("../../../src/app/services/removeService").get;
+
 const res = getResponseMock();
 
-describe('when displaying the remove service access view', () => {
+describe("when displaying the remove service access view", () => {
   let req;
-
-  let getRemoveService;
 
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org-1',
-      name: 'organisation one'
+      id: "org1",
+      name: "organisation one",
     });
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
+      id: "user1",
     });
-    getRemoveService = require('./../../../src/app/services/removeService').get;
   });
 
-  it('then it should get the selected user service', async () => {
+  it("then it should get the selected user service", async () => {
     await getRemoveService(req, res);
 
     expect(getServiceById.mock.calls).toHaveLength(1);
-    expect(getServiceById.mock.calls[0][0]).toBe('service1');
-    expect(getServiceById.mock.calls[0][1]).toBe('correlationId');
+    expect(getServiceById.mock.calls[0][0]).toBe("service1");
+    expect(getServiceById.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should get the organisation details', async () => {
+  it("then it should get the organisation details", async () => {
     await getRemoveService(req, res);
 
     expect(getOrganisationByIdV2.mock.calls).toHaveLength(1);
-    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe('org1');
-    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe('correlationId');
+    expect(getOrganisationByIdV2.mock.calls[0][0]).toBe("org1");
+    expect(getOrganisationByIdV2.mock.calls[0][1]).toBe("correlationId");
   });
 
-  it('then it should return the confirm remove service view', async () => {
+  it("then it should return the confirm remove service view", async () => {
     await getRemoveService(req, res);
 
     expect(res.render.mock.calls.length).toBe(1);
-    expect(res.render.mock.calls[0][0]).toBe('services/views/removeService');
+    expect(res.render.mock.calls[0][0]).toBe("services/views/removeService");
   });
 
-  it('then it should include csrf token', async () => {
+  it("then it should include csrf token", async () => {
     await getRemoveService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: 'token',
+      csrfToken: "token",
     });
   });
 
-  it('then it should include the service details', async () => {
+  it("then it should include the service details", async () => {
     await getRemoveService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       service: {
-        id: 'service1',
-        dateActivated: '10/10/2018',
-        name: 'service name',
-        status: 'active',
+        id: "service1",
+        dateActivated: "10/10/2018",
+        name: "service name",
+        status: "active",
       },
     });
   });
 
-  it('then it should include the org details', async () => {
+  it("then it should include the org details", async () => {
     await getRemoveService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       organisation: {
-        id: 'org-1',
-        name: 'organisation one'
+        id: "org1",
+        name: "organisation one",
       },
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
+    await getRemoveService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await getRemoveService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations`,
+    });
+  });
+
+  it("then it should include back and cancel links with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await getRemoveService(req, res);
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      backLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations/${req.params.oid}?returnOrg=${orgId}`,
+      cancelLink: `/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`,
     });
   });
 });

--- a/test/app/services/removeService.get.test.js
+++ b/test/app/services/removeService.get.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/applications");
 jest.mock("./../../../src/infrastructure/organisations");

--- a/test/app/services/removeService.post.test.js
+++ b/test/app/services/removeService.post.test.js
@@ -1,55 +1,55 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').configMockFactory());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').loggerMockFactory());
-jest.mock('./../../../src/infrastructure/applications');
-jest.mock('./../../../src/infrastructure/organisations');
-jest.mock('./../../../src/infrastructure/access');
-jest.mock('./../../../src/app/services/utils');
-jest.mock('./../../../src/infrastructure/search', () => {
-  return {
-    getSearchDetailsForUserById: jest.fn(),
-    updateIndex: jest.fn(),
-    createIndex: jest.fn(),
-  };
-});
-const { getRequestMock, getResponseMock } = require('./../../utils');
-const { getUserDetails } = require('./../../../src/app/services/utils');
-const { getOrganisationByIdV2 } = require('./../../../src/infrastructure/organisations');
-const { getServiceById } = require('./../../../src/infrastructure/applications');
-const { getSearchDetailsForUserById, updateIndex } = require('./../../../src/infrastructure/search');
-const { removeServiceFromInvitation, removeServiceFromUser } = require('./../../../src/infrastructure/access');
+/* eslint-disable global-require */
+jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+/* eslint-enable global-require */
+jest.mock("./../../../src/infrastructure/applications");
+jest.mock("./../../../src/infrastructure/organisations");
+jest.mock("./../../../src/infrastructure/access");
+jest.mock("./../../../src/infrastructure/search", () => ({
+  getSearchDetailsForUserById: jest.fn(),
+  updateIndex: jest.fn(),
+  createIndex: jest.fn(),
+}));
+
+const { getRequestMock, getResponseMock } = require("../../utils");
+const { getUserDetails } = require("../../../src/app/services/utils");
+const { getOrganisationByIdV2 } = require("../../../src/infrastructure/organisations");
+const { getServiceById } = require("../../../src/infrastructure/applications");
+const { getSearchDetailsForUserById, updateIndex } = require("../../../src/infrastructure/search");
+const { removeServiceFromInvitation, removeServiceFromUser } = require("../../../src/infrastructure/access");
+const postRemoveService = require("../../../src/app/services/removeService").post;
 
 const res = getResponseMock();
 
-describe('when displaying the remove service access view', () => {
+describe("when displaying the remove service access view", () => {
   let req;
-
-  let postRemoveService;
 
   beforeEach(() => {
     req = getRequestMock();
     req.params = {
-      uid: 'user1',
-      oid: 'org1',
-      sid: 'service1',
+      uid: "user1",
+      oid: "org1",
+      sid: "service1",
     };
 
     getServiceById.mockReset();
     getServiceById.mockReturnValue({
-      id: 'service1',
-      dateActivated: '10/10/2018',
-      name: 'service name',
-      status: 'active',
+      id: "service1",
+      dateActivated: "10/10/2018",
+      name: "service name",
+      status: "active",
     });
     getOrganisationByIdV2.mockReset();
     getOrganisationByIdV2.mockReturnValue({
-      id: 'org-1',
-      name: 'organisation one'
+      id: "org-1",
+      name: "organisation one",
     });
     getUserDetails.mockReset();
     getUserDetails.mockReturnValue({
-      id: 'user1',
-      firstName: 'John',
-      lastName: 'Doe'
+      id: "user1",
+      firstName: "John",
+      lastName: "Doe",
     });
 
     getSearchDetailsForUserById.mockReset();
@@ -60,57 +60,65 @@ describe('when displaying the remove service access view', () => {
           name: "organisationId",
           categoryId: "004",
           statusId: 1,
-          roleId: 0
+          roleId: 0,
         },
       ],
-      services: [
-        'service id',
-      ],
+      services: ["service id"],
     });
 
     removeServiceFromUser.mockReset();
     removeServiceFromInvitation.mockReset();
     updateIndex.mockReset();
-
-    postRemoveService = require('./../../../src/app/services/removeService').post;
   });
 
-  it('then it should delete service for invitation if request for invitation', async () => {
-    req.params.uid = 'inv-invite1';
+  it("then it should delete service for invitation if request for invitation", async () => {
+    req.params.uid = "inv-invite1";
 
     await postRemoveService(req, res);
 
     expect(removeServiceFromInvitation.mock.calls).toHaveLength(1);
-    expect(removeServiceFromInvitation.mock.calls[0][0]).toBe('invite1');
-    expect(removeServiceFromInvitation.mock.calls[0][1]).toBe('service1');
-    expect(removeServiceFromInvitation.mock.calls[0][2]).toBe('org1');
-    expect(removeServiceFromInvitation.mock.calls[0][3]).toBe('correlationId');
+    expect(removeServiceFromInvitation.mock.calls[0][0]).toBe("invite1");
+    expect(removeServiceFromInvitation.mock.calls[0][1]).toBe("service1");
+    expect(removeServiceFromInvitation.mock.calls[0][2]).toBe("org1");
+    expect(removeServiceFromInvitation.mock.calls[0][3]).toBe("correlationId");
   });
 
-  it('then it should delete service for user if request for user', async () => {
-
+  it("then it should delete service for user if request for user", async () => {
     await postRemoveService(req, res);
 
     expect(removeServiceFromUser.mock.calls).toHaveLength(1);
-    expect(removeServiceFromUser.mock.calls[0][0]).toBe('user1');
-    expect(removeServiceFromUser.mock.calls[0][1]).toBe('service1');
-    expect(removeServiceFromUser.mock.calls[0][2]).toBe('org1');
-    expect(removeServiceFromUser.mock.calls[0][3]).toBe('correlationId');
+    expect(removeServiceFromUser.mock.calls[0][0]).toBe("user1");
+    expect(removeServiceFromUser.mock.calls[0][1]).toBe("service1");
+    expect(removeServiceFromUser.mock.calls[0][2]).toBe("org1");
+    expect(removeServiceFromUser.mock.calls[0][3]).toBe("correlationId");
   });
 
-
-  it('then a flash message is shown to the user', async () => {
+  it("then a flash message is shown to the user", async () => {
     await postRemoveService(req, res);
 
     expect(res.flash.mock.calls).toHaveLength(1);
-    expect(res.flash).toHaveBeenCalledWith('info', 'John Doe removed from service name');
+    expect(res.flash).toHaveBeenCalledWith("info", "John Doe removed from service name");
   });
 
-
-  it('then it should redirect to user details', async () => {
+  it("then it should redirect to user details without a returnOrg query string, if the returnOrg ID isn't set", async () => {
+    req.query.returnOrg = undefined;
     await postRemoveService(req, res);
-
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
+  });
+
+  it("then it should redirect to user details without a returnOrg query string, if the returnOrg ID is invalid", async () => {
+    req.query.returnOrg = "foo";
+    await postRemoveService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations`);
+  });
+
+  it("then it should redirect to user details with a returnOrg query string, if the returnOrg ID is valid", async () => {
+    const orgId = "7bf1de6d-4799-46f7-ab50-32359f2566ac";
+    req.query.returnOrg = orgId;
+    await postRemoveService(req, res);
+    expect(res.redirect.mock.calls).toHaveLength(1);
+    expect(res.redirect.mock.calls[0][0]).toBe(`/services/${req.params.sid}/users/${req.params.uid}/organisations?returnOrg=${orgId}`);
   });
 });

--- a/test/app/services/removeService.post.test.js
+++ b/test/app/services/removeService.post.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 jest.mock("./../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
 jest.mock("./../../../src/infrastructure/logger", () => require("../../utils").loggerMockFactory());
-jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId"]));
+jest.mock("../../../src/app/services/utils", () => require("../../utils").getPartialMock("src/app/services/utils", ["getReturnOrgId", "getReturnUrl"]));
 /* eslint-enable global-require */
 jest.mock("./../../../src/infrastructure/applications");
 jest.mock("./../../../src/infrastructure/organisations");

--- a/test/app/services/utils.test.js
+++ b/test/app/services/utils.test.js
@@ -1,0 +1,43 @@
+const { getReturnOrgId } = require("../../../src/app/services/utils");
+
+// eslint-disable-next-line global-require
+jest.mock("../../../src/infrastructure/config", () => require("../../utils").configMockFactory());
+
+describe("getReturnOrgId utility function", () => {
+  it("returns null if requestQuery is undefined", () => {
+    const requestQuery = undefined;
+    expect(getReturnOrgId(requestQuery)).toBe(null);
+  });
+
+  it("returns null if requestQuery is falsy", () => {
+    const testValues = [{}, null, false, ""];
+    testValues.forEach((value) => {
+      expect(getReturnOrgId(value)).toBe(null);
+    });
+  });
+
+  it("returns null if requestQuery doesn't have a property named returnOrg", () => {
+    expect(getReturnOrgId({ foo: "bar" })).toBe(null);
+  });
+
+  it("returns null if requestQuery has a property named returnOrg but its value isn't a string", () => {
+    const testValues = [null, {}, [], 12345, new Set()];
+    testValues.forEach((value) => {
+      expect(getReturnOrgId({ returnOrg: value })).toBe(null);
+    });
+  });
+
+  it("returns null if requestQuery has a property named returnOrg but its value isn't in UUID format", () => {
+    const testValues = ["1234", "abcd", "53806309851379017890", "---__-_-", "abcd-efg-hij"];
+    testValues.forEach((value) => {
+      expect(getReturnOrgId({ returnOrg: value })).toBe(null);
+    });
+  });
+
+  it("returns the UUID if requestQuery has a property named returnOrg and its value is in UUID format", () => {
+    const testValues = ["92c653b1-2fc0-42b0-82c4-3f6d9f76e7c3", "c6a8671e-0f7f-4579-956c-288ee31250a4", "ba6afe2a-a4e7-4efe-80a7-5e6e90203d88", "17d34851-1921-4e97-8493-d4bc08cf5db8", "05a0bd5f-2134-4e98-8895-e77af36f7415"];
+    testValues.forEach((value) => {
+      expect(getReturnOrgId({ returnOrg: value })).toBe(value);
+    });
+  });
+});

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -56,6 +56,7 @@ const getRequestMock = (customRequest = {}) => ({
       },
     ],
   },
+  query: {},
   session: {},
   ...customRequest,
 });
@@ -80,9 +81,25 @@ const getResponseMock = () => {
   return res;
 };
 
+const getPartialMock = (pathFromRoot = "", realMethods = []) => {
+  const realModule = jest.requireActual(`../../${pathFromRoot}`);
+  const mockedModule = Object.keys(realModule).reduce((module, methodName) => {
+    // eslint-disable-next-line no-param-reassign
+    module[methodName] = jest.fn();
+    return module;
+  }, {});
+
+  realMethods.forEach((method) => {
+    mockedModule[method] = realModule[method];
+  });
+
+  return mockedModule;
+};
+
 module.exports = {
   loggerMockFactory,
   configMockFactory,
   getRequestMock,
   getResponseMock,
+  getPartialMock,
 };

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,66 +1,64 @@
-const loggerMockFactory = () => {
-  return {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    audit: jest.fn(),
-  };
-};
+const loggerMockFactory = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  audit: jest.fn(),
+});
 
-const configMockFactory = (customConfig) => {
-  return Object.assign({
-    hostingEnvironment: {
-      agentKeepAlive: {},
-      env: 'test-run',
-      servicesUrl: 'https://services.unit.test'
-    },
-    applications: {
-      type: 'static',
-    },
-    access: {
-      type: 'static',
-    },
-    search: {
-      type: 'static',
-    },
-    organisations: {
-      type: 'static',
-    },
-    directories: {
-      type: 'static',
-    },
-    audit: {
-      type: 'static',
-    },
-    serviceMapping: {
-      type: 'static',
-    },
-    notifications:{
-      connectionString: 'test',
-    },
-    loggerSettings: {},
-  }, customConfig);
-};
+const configMockFactory = (customConfig) => ({
+  hostingEnvironment: {
+    agentKeepAlive: {},
+    env: "test-run",
+    servicesUrl: "https://services.unit.test",
+  },
+  applications: {
+    type: "static",
+  },
+  access: {
+    type: "static",
+  },
+  search: {
+    type: "static",
+  },
+  organisations: {
+    type: "static",
+  },
+  directories: {
+    type: "static",
+  },
+  audit: {
+    type: "static",
+  },
+  serviceMapping: {
+    type: "static",
+  },
+  notifications: {
+    connectionString: "test",
+  },
+  loggerSettings: {},
+  ...customConfig,
+});
 
-const getRequestMock = (customRequest = {}) => {
-  return Object.assign({
-    id: 'correlationId',
-    csrfToken: jest.fn().mockReturnValue('token'),
-    accepts: jest.fn().mockReturnValue(['text/html']),
-    params: {},
-    body: {},
-    user: {
-      sub: 'user1',
-      email: 'user@unit.test',
-    },
-    userServices: {
-      roles: [{
-        code: 'serviceid_serviceconfiguration',
-      }],
-    },
-    session: {},
-  }, customRequest);
-};
+const getRequestMock = (customRequest = {}) => ({
+  id: "correlationId",
+  csrfToken: jest.fn().mockReturnValue("token"),
+  accepts: jest.fn().mockReturnValue(["text/html"]),
+  params: {},
+  body: {},
+  user: {
+    sub: "user1",
+    email: "user@unit.test",
+  },
+  userServices: {
+    roles: [
+      {
+        code: "serviceid_serviceconfiguration",
+      },
+    ],
+  },
+  session: {},
+  ...customRequest,
+});
 
 const getResponseMock = () => {
   const res = {
@@ -70,12 +68,12 @@ const getResponseMock = () => {
     contentType: jest.fn(),
     send: jest.fn(),
     flash: jest.fn(),
-    mockResetAll: function () {
+    mockResetAll() {
       this.render.mockReturnValue(res);
       this.redirect.mockReturnValue(res);
       this.status.mockReturnValue(res);
       this.contentType.mockReturnValue(res);
-    }
+    },
   };
 
   res.mockResetAll();


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8144

## Summary

The below changes cover when going from a searched organisation user list, clicking on a user, and doing any of the following things:

- Viewing user audit (and updating/going to a new page).
- Editing a user's access (as well as clicking back/cancel).
- Adding service access to a user (as well as clicking back/cancel).
- Removing a user's access (as well as clicking back/cancel).

That when we click on "Back" from the user's organisation list, we can get back to the originally searched for organisation. There were some initial changes for this as part of a previous bugfix (NSA-7406), but these broke the edit service functionality when going from organisation to user, as well as confirming adding a service.

## Implementation

To address the bugs outlined in the ticket, and to ensure the functionality is consistent across all user routes when coming from an organisation, the ID from the organisation is added as a query parameter with the name `returnOrg`. This is propagated through all routes from the user's organisation list, so when we click on "Back" we will always end up at the organisation we searched for.

This was chosen as the best option, the others being using sessions which would cause issues with multiple tabs, and keeping it in the URL which would mean doubling our routes for an optional field, making things more confusing to understand in future.

## Changes

- `src/app/services/utils.js`:
  - `getReturnOrgId(requestQuery)`: This method checks that the request query passed is an object, that it has a property called `returnOrg`, that the value of `returnOrg` is a string, and that it's in UUID format. If it is, it returns the value of `returnOrg`, otherwise it returns `null`.
    - This method is unit tested (`test/app/services/utils.test.js`) as it's performing multiple validation steps, and we don't want any errors to be thrown because the value doesn't exist or gets modified elsewhere.
  - `getReturnUrl(requestQuery, url)`: This method appends the `returnOrg` query string to `url` if the return organisation ID is valid, otherwise it returns `url` without any changes.
    - This method isn't tested itself, but the routes requiring `returnOrg` to be appended are tested to ensure the URL is adjusted when `returnOrg` was passed and valid.
- `*.ejs`:
  - `src/app/services/views/organisationUserList.ejs`: Adds `returnOrg` to each of the user details URLs in the list.
  - `src/app/services/views/audit.ejs`: Adds `returnOrg` to the pagination data, so it's appended to the URL for the page links.
  - For all other EJS files, we are appending the `returnOrg` to any hardcoded links if it exists, and where the back and cancel links are identical, replacing the cancel link with the back link URLs.
- `src/app/services/*.js`: For all routes that come from a user's organisation list, all of them have been updated to use `getReturnOrgId` if the ID is required in the `ejs` template, and `getReturnUrl` for any back/cancel links. The only exceptions to this are if the URL changes completely if `returnOrg` is set, where they use `getReturnOrgId` and an `if` statement.
  - The URLs being correct/appended with `returnOrg`, as well as the return org ID being present in the model is unit tested for all applicable routes, for it not being set, it being invalid (non-UUID string), and being valid.
- `test/utils/index.js`: Adds `getPartialMock` which takes the path to the module from the project root, and an array of method names which need their real implementations instead of mocks.
  - The reason this is needed for these tests is `src/app/services/utils.js` uses external sources for some of its functionality, so those need to be mocked by pure utility functions such as `getReturnOrgId` or `getReturnUrl` need their real implementations.
- ESLint fixes across all modified files.