### PR TITLE
Update `content-security-policy` header (ITHC/DSI-7012)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.manage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.manage",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.5.0",
@@ -378,16 +378,24 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.9.1.tgz",
-      "integrity": "sha1-HcAn9jeJYSzN9J2nIqaAAdQ0oE4=",
+      "version": "2.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.9.2.tgz",
+      "integrity": "sha1-5tPBZhASwb0O9o4yj3Oi/e3lKTE=",
       "dependencies": {
-        "@azure/msal-common": "14.11.0",
+        "@azure/msal-common": "14.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "14.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.12.0.tgz",
+      "integrity": "sha1-hEq+JpsHH4+olJ2twqe2W7sUdYg=",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.manage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "scripts": {
     "lint": "eslint",

--- a/src/index.js
+++ b/src/index.js
@@ -48,48 +48,44 @@ const init = async () => {
   });
   const app = express();
 
+  logger.info('set helmet policy defaults');
+  
+  const self = "'self'";
+  const allowedOrigin = '*.signin.education.gov.uk';
+
   if (config.hostingEnvironment.hstsMaxAge) {
     app.use(helmet({
-      noCache: true,
-      frameguard: {
-        action: 'deny',
-      },
-      hsts: {
+      strictTransportSecurity: {
         maxAge: config.hostingEnvironment.hstsMaxAge,
         preload: true,
+        includeSubDomains: true,
       },
     }));
   }
-  logger.info('set helmet policy defaults');
-
-  const scriptSources = ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'localhost', '*.signin.education.gov.uk'];
-  const styleSources = ["'self'", "'unsafe-inline'", 'localhost', '*.signin.education.gov.uk'];
-  const imgSources = ["'self'", 'data:', 'blob:', 'localhost', '*.signin.education.gov.uk'];
-  const fontSources = ["'self'", 'data:', '*.signin.education.gov.uk'];
+  
+  // Setting helmet Content Security Policy
+  const scriptSources = [self, "'unsafe-inline'", "'unsafe-eval'", allowedOrigin];
+  const styleSources = [self, "'unsafe-inline'", allowedOrigin];
+  const imgSources = [self, 'data:', 'blob:', allowedOrigin];
+  const fontSources = [self, 'data:', allowedOrigin];
 
   if (config.hostingEnvironment.env === 'dev') {
-    scriptSources.push('https://localhost:3001');
-    styleSources.push('https://localhost:3001');
-    imgSources.push('https://localhost:3001');
-    fontSources.push('https://localhost:3001');
+    scriptSources.push('localhost');
+    styleSources.push('localhost');
+    imgSources.push('localhost');
+    fontSources.push('localhost');
   }
 
-  // Setting helmet Content Security Policy
 
   app.use(helmet.contentSecurityPolicy({
-    browserSniff: false,
-    setAllHeaders: false,
-    useDefaults: false,
     directives: {
-      defaultSrc: ["'self'"],
-      childSrc: ["'none'"],
-      objectSrc: ["'none'"],
+      defaultSrc: [self],
       scriptSrc: scriptSources,
       styleSrc: styleSources,
       imgSrc: imgSources,
       fontSrc: fontSources,
-      connectSrc: ["'self'"],
-      formAction: ["'self'", '*'],
+      connectSrc: [self],
+      formAction: [self, '*'],
     },
   }));
 


### PR DESCRIPTION
At the time of writing the `content-security-header` wasn't as secure as it could be; namely, it listed `localhost` in production, and didn't include the property `upgrade-insecure-requests`.

Following this change the `content-security-header` includes `upgrade-insecure-requests` and only outputs `localhost` in development.