### PR TITLE
Feature/NSA-8339 Disable Cross-Origin-Opener-Policy which was inadvertently introduced and set to same-origin by helmetjs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,18 +69,22 @@ const init = async () => {
     fontSources.push('localhost');
   }
 
-
-  app.use(helmet.contentSecurityPolicy({
-    directives: {
-      defaultSrc: [self],
-      scriptSrc: scriptSources,
-      styleSrc: styleSources,
-      imgSrc: imgSources,
-      fontSrc: fontSources,
-      connectSrc: [self],
-      formAction: [self, '*'],
-    },
-  }));
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: [self],
+          scriptSrc: scriptSources,
+          styleSrc: styleSources,
+          imgSrc: imgSources,
+          fontSrc: fontSources,
+          connectSrc: [self],
+          formAction: [self, '*'],
+        },
+      },
+      crossOriginOpenerPolicy: { policy: "unsafe-none" }, // crossOriginOpenerPolicy: false is ignored and unsafe-none is the default on MDM
+    }),
+  );
 
   logger.info('Set helmet filters');
 


### PR DESCRIPTION
'crossOriginOpenerPolicy: false' is being ignored by helmet (despite their documentation) - it sets same-origin and unsafe-none is the default on MDM. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy