### PR TITLE
[NSA-9323] Hide remove button for people without role

### DIFF
--- a/src/app/services/views/policyConditionsAndRoles.ejs
+++ b/src/app/services/views/policyConditionsAndRoles.ejs
@@ -88,13 +88,17 @@
                                         <% for (let i = 0; i < condition.mappedValues.length; i++) {
                                             const selectedCondition = condition.mappedValues[i];
                                         %>
-                                            <p><%= selectedCondition.friendlyValue %> <a href="confirm-remove-policy-condition?condition=<%= condition.field %>&operator=<%= condition.operator %>&value=<%= selectedCondition.value %>">Remove</a></p>
+                                            <p>
+                                                <%= selectedCondition.friendlyValue %>
+                                                <%  if (locals.canUserModifyPolicyConditions) { %>
+                                                <a href="confirm-remove-policy-condition?condition=<%= condition.field %>&operator=<%= condition.operator %>&value=<%= selectedCondition.value %>">Remove</a>
+                                                <% } %>
+                                            </p>
                                         <% } %>
                                         </div>
                                     </details>
                                 </td>
-                            <% }%>
-
+                            <% } %>
                             </tr>
                         <% } %>
                         </tbody>


### PR DESCRIPTION
Remove link was being displayed for all users (as opposed to the ones with the `internalServiceConfigurationManager`) for the multi value records.
There was authentication on the endpoint so if you clicked it and didn't have the role, then it would give you an unauthorised message back.