### PR TITLE
[NSA-9321] Fix policy condition navigation

### DIFF
--- a/src/app/services/getConfirmCreatePolicyCondition.js
+++ b/src/app/services/getConfirmCreatePolicyCondition.js
@@ -21,6 +21,7 @@ const getConfirmCreatePolicyCondition = async (req, res) => {
     policy,
     cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/create-policy-condition`,
     backLink: `/services/${req.params.sid}/policies/${req.params.pid}/create-policy-condition`,
+    serviceId: req.params.sid,
     currentNavigation: "policies",
     userRoles: manageRolesForService,
   });

--- a/src/app/services/getConfirmRemovePolicyCondition.js
+++ b/src/app/services/getConfirmRemovePolicyCondition.js
@@ -34,6 +34,7 @@ const getConfirmRemovePolicyCondition = async (req, res) => {
     friendlyValue,
     cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
     backLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    serviceId: req.params.sid,
     currentNavigation: "policies",
     userRoles: manageRolesForService,
   });

--- a/src/app/services/getCreatePolicyCondition.js
+++ b/src/app/services/getCreatePolicyCondition.js
@@ -14,6 +14,7 @@ const getCreatePolicyCondition = async (req, res) => {
     policy,
     cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
     backLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    serviceId: req.params.sid,
     currentNavigation: "policies",
     userRoles: manageRolesForService,
   });

--- a/src/app/services/postCreatePolicyCondition.js
+++ b/src/app/services/postCreatePolicyCondition.js
@@ -127,6 +127,7 @@ const postCreatePolicyCondition = async (req, res) => {
       policy,
       cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
       backLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+      serviceId: req.params.sid,
       currentNavigation: "policies",
       userRoles: manageRolesForService,
     });
@@ -150,6 +151,7 @@ const postCreatePolicyCondition = async (req, res) => {
         policy,
         cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
         backLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+        serviceId: req.params.sid,
         currentNavigation: "policies",
         userRoles: manageRolesForService,
       });

--- a/test/app/services/confirmServiceConfig.get.test.js
+++ b/test/app/services/confirmServiceConfig.get.test.js
@@ -163,26 +163,18 @@ describe("when getting the Review service config changes page", () => {
     );
   });
 
-  it("then it should include csrf token in model", async () => {
+  it("then it should include correct data in model", async () => {
     await getConfirmServiceConfig(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
+      backLink: "/services/service1/service-configuration",
+      cancelLink: "/services/service1",
+      currentNavigation: "configuration",
+      service: {
+        name: "service one",
+      },
     });
-  });
-
-  it("then it should set the back link correctly in the model", async () => {
-    await getConfirmServiceConfig(req, res);
-
-    expect(res.render.mock.calls[0][1].backLink).toBe(
-      "/services/service1/service-configuration",
-    );
-  });
-
-  it("then it should set the cancel link correctly in the model", async () => {
-    await getConfirmServiceConfig(req, res);
-
-    expect(res.render.mock.calls[0][1].cancelLink).toBe("/services/service1");
   });
 
   it("then it should include user roles in the model", async () => {
@@ -191,24 +183,6 @@ describe("when getting the Review service config changes page", () => {
 
     await getConfirmServiceConfig(req, res);
     expect(res.render.mock.calls[0][1].userRoles).toEqual(mockRoles);
-  });
-
-  it('then it should set currentNavigation to "configuration"', async () => {
-    await getConfirmServiceConfig(req, res);
-
-    expect(res.render.mock.calls[0][1].currentNavigation).toEqual(
-      "configuration",
-    );
-  });
-
-  it("then it should include the service name in the model", async () => {
-    await getConfirmServiceConfig(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      service: {
-        name: "service one",
-      },
-    });
   });
 
   it("then it should include sorted serviceChanges, with the right description and the right change link in the model", async () => {

--- a/test/app/services/getConfirmCreatePolicyCondition.test.js
+++ b/test/app/services/getConfirmCreatePolicyCondition.test.js
@@ -81,24 +81,17 @@ describe("when using the getConfirmCreatePolicyCondition function", () => {
     );
   });
 
-  it("should include csrf token in model", async () => {
-    await getConfirmCreatePolicyCondition(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-    });
-  });
-
   it("should include the following in the model on success", async () => {
     await getConfirmCreatePolicyCondition(req, res);
 
-    expect(res.render.mock.calls[0][1]).toMatchObject({
+    expect(res.render.mock.calls[0][1]).toStrictEqual({
       condition: "organisation.urn",
       operator: "is",
       value: "123456",
       backLink: "/services/service-1/policies/policy-1/create-policy-condition",
       cancelLink:
         "/services/service-1/policies/policy-1/create-policy-condition",
+      serviceId: "service-1",
       csrfToken: "token",
       currentNavigation: "policies",
       policy: policy,

--- a/test/app/services/getConfirmRemovePolicyCondition.test.js
+++ b/test/app/services/getConfirmRemovePolicyCondition.test.js
@@ -86,18 +86,10 @@ describe("when using the getConfirmRemovePolicyCondition function", () => {
     );
   });
 
-  it("should include csrf token in model", async () => {
-    await getConfirmRemovePolicyCondition(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-    });
-  });
-
   it("should include the following in the model on success", async () => {
     await getConfirmRemovePolicyCondition(req, res);
 
-    expect(res.render.mock.calls[0][1]).toMatchObject({
+    expect(res.render.mock.calls[0][1]).toStrictEqual({
       condition: "organisation.urn",
       operator: "is",
       value: "123456",
@@ -105,6 +97,7 @@ describe("when using the getConfirmRemovePolicyCondition function", () => {
       friendlyValue: ["123456"],
       backLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
       cancelLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
+      serviceId: "service-1",
       csrfToken: "token",
       currentNavigation: "policies",
       policy: policy,

--- a/test/app/services/getCreatePolicyCondition.test.js
+++ b/test/app/services/getCreatePolicyCondition.test.js
@@ -73,20 +73,13 @@ describe("when using the getCreatePolicyCondition function", () => {
     );
   });
 
-  it("should include csrf token in model", async () => {
-    await getCreatePolicyCondition(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-    });
-  });
-
   it("should include the following in the model on success", async () => {
     await getCreatePolicyCondition(req, res);
 
-    expect(res.render.mock.calls[0][1]).toMatchObject({
+    expect(res.render.mock.calls[0][1]).toStrictEqual({
       backLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
       cancelLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
+      serviceId: "service-1",
       csrfToken: "token",
       currentNavigation: "policies",
       policy: policy,

--- a/test/app/services/getNewServiceBanner.test.js
+++ b/test/app/services/getNewServiceBanner.test.js
@@ -48,14 +48,6 @@ describe("when getting the create new service banner view", () => {
     expect(res.render.mock.calls[0][0]).toBe("services/views/newServiceBanner");
   });
 
-  it("then it should include csrf token", async () => {
-    await getNewServiceBanner(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-    });
-  });
-
   it("then it should get the banner by id if editing banner", async () => {
     await getNewServiceBanner(req, res);
 
@@ -66,7 +58,7 @@ describe("when getting the create new service banner view", () => {
     });
   });
 
-  it("then it should include the banner being edited details", async () => {
+  it("then it should include the banner being edited details and csrf token", async () => {
     await getNewServiceBanner(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
@@ -74,6 +66,7 @@ describe("when getting the create new service banner view", () => {
       name: "banner name",
       bannerTitle: "banner title",
       message: "banner message",
+      csrfToken: "token",
     });
   });
 

--- a/test/app/services/getPolicyConditionsAndRoles.test.js
+++ b/test/app/services/getPolicyConditionsAndRoles.test.js
@@ -73,14 +73,6 @@ describe("When displaying the selected policy's conditions and roles", () => {
     );
   });
 
-  it("then it should include csrf token", async () => {
-    await getPolicyConditions(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-    });
-  });
-
   it("then it should get the service by id", async () => {
     await getPolicyConditions(req, res);
 
@@ -100,10 +92,11 @@ describe("When displaying the selected policy's conditions and roles", () => {
     });
   });
 
-  it("then it should include the mapped policy", async () => {
+  it("then it should include the mapped policy and csrf token", async () => {
     await getPolicyConditions(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
+      csrfToken: "token",
       policy: {
         applicationId: "service1",
         conditions: [

--- a/test/app/services/getServiceBanners.test.js
+++ b/test/app/services/getServiceBanners.test.js
@@ -100,18 +100,11 @@ describe("when getting the list of service banners page", () => {
     expect(res.render.mock.calls[0][0]).toBe("services/views/serviceBanners");
   });
 
-  it("then it should include csrf token in model", async () => {
+  it("then it should include the service banners list in the model and csrf token", async () => {
     await getServiceBanners(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
-    });
-  });
-
-  it("then it should include the service banners list in the model", async () => {
-    await getServiceBanners(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
       serviceBanners: [
         {
           serviceId: "serviceid",

--- a/test/app/services/postCreatePolicyCondition.test.js
+++ b/test/app/services/postCreatePolicyCondition.test.js
@@ -172,6 +172,7 @@ describe("when posting the create policy condition page", () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       backLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
       cancelLink: "/services/service-1/policies/policy-1/conditionsAndRoles",
+      serviceId: "service-1",
       csrfToken: "token",
       currentNavigation: "policies",
       policy: policy,

--- a/test/app/services/removeService.get.test.js
+++ b/test/app/services/removeService.get.test.js
@@ -79,18 +79,11 @@ describe("when displaying the remove service access view", () => {
     expect(res.render.mock.calls[0][0]).toBe("services/views/removeService");
   });
 
-  it("then it should include csrf token", async () => {
+  it("then it should include the service details and csrf token", async () => {
     await getRemoveService(req, res);
 
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
-    });
-  });
-
-  it("then it should include the service details", async () => {
-    await getRemoveService(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
       service: {
         id: "service1",
         dateActivated: "10/10/2018",


### PR DESCRIPTION
The top bar navigation (dashboard, configuration, etc) didn't have the serviceId in it so it would break when you tried to navigate away (the back and cancel buttons worked through).
This PR fixes that for the remove policy condition, create policy condition and confirm create policy condition pages.

This PR also tidies up a number of tests.  `isStrictEqual` is a better test then `toMatchObject` because the latter doesn't test for the absence of a field.  Also the csrf token tests being standalone is a waste of time, so I merged them into other tests in a number of files