### PR TITLE
NSA-9729: Manage Console: show organisation status in User Management

### DIFF
--- a/src/app/services/getUserOrganisations.js
+++ b/src/app/services/getUserOrganisations.js
@@ -13,6 +13,25 @@ const {
   getUserServiceRoles,
   getReturnOrgId,
 } = require("./utils");
+
+// Maps organisation status names to GOV.UK tag colour modifiers.
+// Extend this object if new org statuses are introduced upstream.
+const orgStatusTagColourMap = {
+  open: "green",
+  active: "green",
+  invited: "blue",
+  pending: "blue",
+  proposed: "blue",
+  "pending activation": "blue",
+  suspended: "yellow",
+  "proposed to close": "yellow",
+  closed: "red",
+};
+
+const getOrgStatusTagColour = (statusName) => {
+  if (!statusName) return "";
+  return orgStatusTagColourMap[statusName.toLowerCase()] ?? "";
+};
 const logger = require("../../infrastructure/logger");
 const { getServiceRaw } = require("login.dfe.api-client/services");
 const {
@@ -83,11 +102,20 @@ const getOrganisations = async (userId) => {
         return service;
       });
 
+      const rawStatus = invitation.organisation.status;
+      const mappedStatus = rawStatus
+        ? {
+            ...rawStatus,
+            tagColor:
+              rawStatus.tagColor || getOrgStatusTagColour(rawStatus.name),
+          }
+        : rawStatus;
+
       return {
         id: invitation.organisation.id,
         name: invitation.organisation.name,
         LegalName: invitation.organisation.LegalName,
-        status: invitation.organisation.status,
+        status: mappedStatus,
         role: invitation.role,
         urn: invitation.organisation.urn,
         uid: invitation.organisation.uid,

--- a/src/app/services/getUserOrganisations.js
+++ b/src/app/services/getUserOrganisations.js
@@ -107,7 +107,7 @@ const getOrganisations = async (userId) => {
         ? {
             ...rawStatus,
             tagColor:
-              rawStatus.tagColor || getOrgStatusTagColour(rawStatus.name),
+              rawStatus.tagColor ?? getOrgStatusTagColour(rawStatus.name),
           }
         : rawStatus;
 

--- a/src/app/services/views/userOrganisations.ejs
+++ b/src/app/services/views/userOrganisations.ejs
@@ -27,6 +27,13 @@
 								<dt class="govuk-label"><%=org.name%></dt>
 								<%}%>
 							<%}%>
+						<% if (org.status && org.status.name) { %>
+						<dd class="govuk-label">
+							<strong class="govuk-tag govuk-tag--<%= org.status.tagColor %>">
+								<%=org.status.name%>
+							</strong>
+						</dd>
+						<% } %>
 						<% if (!locals.isInvitation) { %>
 						<dt class="govuk-label govuk-!-font-weight-regular">Legacy ID:</dt>
 						<dd class="govuk-label"><%= org.numericIdentifier %></dd>
@@ -52,16 +59,7 @@
 								</div>
 								<div class="meta js-hidden">
 									<div class="approvers">
-                                        <% if (org.status && org.status.name) { %>
-                                            <dl class="inline condensed small-dt govuk-summary-list govuk-summary-list--no-border">
-                                        <dt class="govuk-label">Organisation Status:</dt>
-                                        <dd>
-                                            <strong class="govuk-tag govuk-tag--<%= org.status.tagColor %>">
-                                                <%=org.status.name%>
-                                            </strong>
-                                        </dd>
-                                        </dl>
-                                        <% } %>
+
 										<dl class="inline condensed small-dt govuk-summary-list govuk-summary-list--no-border">
 											<% if (org.LegalName) { %>
 											<dt class="govuk-label"><abbr title="Registered legal name">Legal name: </abbr></dt>

--- a/src/app/services/views/userOrganisations.ejs
+++ b/src/app/services/views/userOrganisations.ejs
@@ -29,7 +29,7 @@
 							<%}%>
 						<% if (org.status && org.status.name) { %>
 						<dd class="govuk-label">
-							<strong class="govuk-tag govuk-tag--<%= org.status.tagColor %>">
+							<strong class="govuk-tag<% if (org.status.tagColor) { %> govuk-tag--<%= org.status.tagColor %><% } %>">
 								<%=org.status.name%>
 							</strong>
 						</dd>

--- a/test/app/services/getUserOrganisations.test.js
+++ b/test/app/services/getUserOrganisations.test.js
@@ -107,6 +107,7 @@ describe("when getting users organisation details", () => {
         organisation: {
           id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
           name: "Great Big School",
+          status: { id: 1, name: "Open" },
         },
         approvers: ["user1"],
         services: [
@@ -362,6 +363,84 @@ describe("when getting users organisation details", () => {
           ],
         },
       ],
+    });
+  });
+
+  describe("organisation status tag colour mapping", () => {
+    const statusCases = [
+      { name: "Open", expectedTagColor: "green" },
+      { name: "Active", expectedTagColor: "green" },
+      { name: "Invited", expectedTagColor: "blue" },
+      { name: "Pending", expectedTagColor: "blue" },
+      { name: "Proposed", expectedTagColor: "blue" },
+      { name: "Pending Activation", expectedTagColor: "blue" },
+      { name: "Suspended", expectedTagColor: "yellow" },
+      { name: "Proposed to Close", expectedTagColor: "yellow" },
+      { name: "Closed", expectedTagColor: "red" },
+      { name: "Unknown Status", expectedTagColor: "" },
+    ];
+
+    statusCases.forEach(({ name: statusName, expectedTagColor }) => {
+      it(`should set tagColor "${expectedTagColor}" for status "${statusName}"`, async () => {
+        getUserOrganisationsWithServicesRaw.mockReturnValue([
+          {
+            organisation: {
+              id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+              name: "Test School",
+              status: { id: 1, name: statusName },
+            },
+            approvers: [],
+            services: [],
+          },
+        ]);
+
+        await getUserOrganisations(req, res);
+
+        expect(
+          res.render.mock.calls[0][1].organisations[0].status,
+        ).toMatchObject({
+          name: statusName,
+          tagColor: expectedTagColor,
+        });
+      });
+    });
+
+    it("should preserve tagColor already provided by the API", async () => {
+      getUserOrganisationsWithServicesRaw.mockReturnValue([
+        {
+          organisation: {
+            id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+            name: "Test School",
+            status: { id: 1, name: "Open", tagColor: "purple" },
+          },
+          approvers: [],
+          services: [],
+        },
+      ]);
+
+      await getUserOrganisations(req, res);
+
+      expect(res.render.mock.calls[0][1].organisations[0].status.tagColor).toBe(
+        "purple",
+      );
+    });
+
+    it("should handle a null status without throwing", async () => {
+      getUserOrganisationsWithServicesRaw.mockReturnValue([
+        {
+          organisation: {
+            id: "88a1ed39-5a98-43da-b66e-78e564ea72b0",
+            name: "Test School",
+            status: null,
+          },
+          approvers: [],
+          services: [],
+        },
+      ]);
+
+      await getUserOrganisations(req, res);
+
+      expect(res.render.mock.calls[0][1].organisations[0].status).toBeNull();
     });
   });
 });


### PR DESCRIPTION
**Changes:**

- Added orgStatusTagColourMap + getOrgStatusTagColour to compute GOV.UK tag colours for organisation statuses.
- Updated getUserOrganisations() to enrich each organisation’s status with a tagColor.
- Updated userOrganisations.ejs to display the organisation status tag next to the organisation name.
- Removed the old hidden status block inside .meta.js-hidden.
- Updated test fixtures to include organisation status.
- Added unit tests covering status