### PR TITLE
NSA-9688: Add "Hide Service" checkbox to edit service configuration page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "helmet": "^7.2.0",
         "ioredis": "^5.9.2",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.61",
+        "login.dfe.api-client": "^1.0.64",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -51,14 +51,16 @@
         "eslint-plugin-jest": "^28.14.0",
         "globals": "^15.14.0",
         "husky": "^9.1.7",
-        "ioredis-mock": "^8.9.0",
+        "ioredis-mock": "^8.13.1",
         "jest": "^29.6.3",
         "jest-cli": "^29.6.3",
         "jest-junit": "^16.0.0",
         "lint-staged": "^15.5.2",
+        "memorystore": "^1.6.8",
         "node-mocks-http": "^1.17.2",
         "nodemon": "^3.1.11",
-        "prettier": "^3.8.1"
+        "prettier": "^3.8.1",
+        "session-file-store": "^1.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2321,9 +2323,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ioredis-mock": {
-      "version": "8.2.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ioredis-mock/-/ioredis-mock-8.2.6.tgz",
-      "integrity": "sha1-78gLL+cC08O57nDz/gWjbBiypSg=",
+      "version": "8.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ioredis-mock/-/ioredis-mock-8.2.7.tgz",
+      "integrity": "sha1-SgQdV1LXs9aG7o6qyUkQ7uB1EyE=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2888,6 +2890,19 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-2.6.4.tgz",
@@ -3057,6 +3072,13 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/bagpipe": {
+      "version": "0.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bagpipe/-/bagpipe-0.3.5.tgz",
+      "integrity": "sha1-40HRZPyyTN8E6n4Ft2XsEMiupqE=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3113,6 +3135,13 @@
         "inherits": "^2.0.4",
         "readable-stream": "^4.2.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha1-LMLGeRiOs1sAby0NRxC+2EN6dp4=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -5046,6 +5075,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5844,6 +5888,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.0",
@@ -6689,6 +6740,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -6755,6 +6816,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kruptein": {
+      "version": "2.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/kruptein/-/kruptein-2.2.3.tgz",
+      "integrity": "sha1-4Jo5QrgHKscXKNEP4IkpPgtefUI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">6"
       }
     },
     "node_modules/kuler": {
@@ -7253,9 +7327,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.61",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.61.tgz",
-      "integrity": "sha1-83/BAqO6ur/9PtHCZzjJjTQWxJI=",
+      "version": "1.0.64",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.64.tgz",
+      "integrity": "sha1-Na/zn0jpCnE1D8coAGWMvqjZnck=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",
@@ -7443,6 +7517,63 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memorystore": {
+      "version": "1.6.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/memorystore/-/memorystore-1.6.8.tgz",
+      "integrity": "sha1-g3vU+j9XJ8I1ZmJ2Z4uaP4z52EA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/memorystore/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/memorystore/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/memorystore/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/memorystore/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -7556,6 +7687,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -7896,6 +8034,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
@@ -8585,6 +8733,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -9283,6 +9438,47 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/session-file-store": {
+      "version": "1.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/session-file-store/-/session-file-store-1.5.0.tgz",
+      "integrity": "sha1-n6/8GMLij1f+fE5MhM3JK7IIM/Q=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bagpipe": "^0.3.5",
+        "fs-extra": "^8.0.1",
+        "kruptein": "^2.0.4",
+        "object-assign": "^4.1.1",
+        "retry": "^0.12.0",
+        "write-file-atomic": "3.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/session-file-store/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/session-file-store/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -9906,10 +10102,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha1-2TRQzd7FFUotXKvjuBArgzFvsqY=",
+      "version": "5.9.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -9945,6 +10151,16 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha1-SsLgWM5WtGKwVuYpzGoCOT0/81A=",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
+    "dev:local": "nodemon --require ./redis-mock-shim.js src/index.js",
     "dev:checks": "npm run lint && npm run test",
     "format": "prettier . --write",
     "lint": "eslint .",
@@ -42,7 +43,7 @@
     "helmet": "^7.2.0",
     "ioredis": "^5.9.2",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.61",
+    "login.dfe.api-client": "^1.0.64",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.winston-sequelize-transport": "^3.2.6",
     "login.dfe.config.schema.common": "^2.1.8",
@@ -69,14 +70,16 @@
     "eslint-plugin-jest": "^28.14.0",
     "globals": "^15.14.0",
     "husky": "^9.1.7",
-    "ioredis-mock": "^8.9.0",
+    "ioredis-mock": "^8.13.1",
     "jest": "^29.6.3",
     "jest-cli": "^29.6.3",
     "jest-junit": "^16.0.0",
     "lint-staged": "^15.5.2",
+    "memorystore": "^1.6.8",
     "node-mocks-http": "^1.17.2",
     "nodemon": "^3.1.11",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "session-file-store": "^1.5.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/redis-mock-shim.js
+++ b/redis-mock-shim.js
@@ -1,0 +1,9 @@
+const Module = require("module");
+const originalLoad = Module._load;
+
+Module._load = function (request, parent, isMain) {
+  if (request === "ioredis") {
+    return require("ioredis-mock");
+  }
+  return originalLoad.apply(this, arguments);
+};

--- a/redis-mock-shim.js
+++ b/redis-mock-shim.js
@@ -1,9 +1,1 @@
-const Module = require("module");
-const originalLoad = Module._load;
 
-Module._load = function (request, parent, isMain) {
-  if (request === "ioredis") {
-    return require("ioredis-mock");
-  }
-  return originalLoad.apply(this, arguments);
-};

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -637,7 +637,8 @@ const postConfirmServiceConfig = async (req, res) => {
       if (hideServiceChange.isIdOnlyService) {
         paramUpdates.push(
           updateService(serviceId, {
-            isHiddenService: hideServiceChange.newValue,
+            // API requires integer 1/0, not boolean.
+            isHiddenService: hideServiceChange.newValue ? 1 : 0,
           }),
         );
       }

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -577,18 +577,17 @@ const postConfirmServiceConfig = async (req, res) => {
       hideServiceChange &&
       hideServiceChange.newValue !== hideServiceChange.oldValue
     ) {
-      const hiddenValue = hideServiceChange.newValue ? "true" : "false";
-      const serviceId = req.params.sid;
-
       // TODO: implement updateServiceParam in login.dfe.api-client
+      // const hiddenValue = hideServiceChange.newValue ? "true" : "false";
+      // const serviceId = req.params.sid;
       // await updateServiceParam(serviceId, 'hideApprover', hiddenValue);
       // await updateServiceParam(serviceId, 'hideSupport', hiddenValue);
       // await updateServiceParam(serviceId, 'helpHidden', hiddenValue);
 
       if (hideServiceChange.isIdOnlyService) {
-        const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
         // TODO: implement isHiddenService update in login.dfe.api-client
-        // await updateService(serviceId, { isHiddenService: isHiddenServiceValue });
+        // const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
+        // await updateService(req.params.sid, { isHiddenService: isHiddenServiceValue });
       }
     }
 

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -167,11 +167,11 @@ const validate = async (req, currentService) => {
     const { serviceHome, postResetUrl, clientId } = model.service;
     if (model.service.postLogoutRedirectUris === undefined) {
       model.service.postLogoutRedirectUris =
-        serviceConfigurationChanges.postLogoutRedirectUris.oldValue;
+        serviceConfigurationChanges.postLogoutRedirectUris?.oldValue;
     }
     if (model.service.redirectUris === undefined) {
       model.service.redirectUris =
-        serviceConfigurationChanges.redirectUris.oldValue;
+        serviceConfigurationChanges.redirectUris?.oldValue;
     }
     // Only validate serviceHome if it was part of the submitted changes.
     // When only hideService changed, serviceHome is not in the session and
@@ -224,46 +224,51 @@ const validate = async (req, currentService) => {
       }
     }
 
-    const postUrlValidator = new UrlValidator(postResetUrl);
-    const isPostResetUrlValid = await isValidUrl(postUrlValidator);
-    if (postResetUrl && !isPostResetUrlValid) {
-      if (
-        model.validationMessages.postResetUrl !== "" &&
-        model.validationMessages.postResetUrl !== undefined
-      ) {
-        model.validationMessages.postResetUrl +=
-          ERROR_MESSAGES.INVALID_RESETPASS_CHARACTERS;
-      } else {
-        model.validationMessages.postResetUrl =
-          ERROR_MESSAGES.INVALID_RESETPASS_CHARACTERS;
+    // Only validate postResetUrl if it was part of the submitted changes.
+    // When only hideService changed, postResetUrl is not in the session and
+    // should not be re-validated.
+    if (postResetUrl !== undefined) {
+      const postUrlValidator = new UrlValidator(postResetUrl);
+      const isPostResetUrlValid = await isValidUrl(postUrlValidator);
+      if (postResetUrl && !isPostResetUrlValid) {
+        if (
+          model.validationMessages.postResetUrl !== "" &&
+          model.validationMessages.postResetUrl !== undefined
+        ) {
+          model.validationMessages.postResetUrl +=
+            ERROR_MESSAGES.INVALID_RESETPASS_CHARACTERS;
+        } else {
+          model.validationMessages.postResetUrl =
+            ERROR_MESSAGES.INVALID_RESETPASS_CHARACTERS;
+        }
       }
-    }
 
-    const isPOstResetUrlToLength = await isCorrectLength(postUrlValidator);
-    if (!isPOstResetUrlToLength) {
-      if (
-        model.validationMessages.postResetUrl !== "" &&
-        model.validationMessages.postResetUrl !== undefined
-      ) {
-        model.validationMessages.postResetUrl +=
-          ERROR_MESSAGES.INVALID_RESETPASS_LENTGH;
-      } else {
-        model.validationMessages.postResetUrl =
-          ERROR_MESSAGES.INVALID_RESETPASS_LENTGH;
+      const isPOstResetUrlToLength = await isCorrectLength(postUrlValidator);
+      if (!isPOstResetUrlToLength) {
+        if (
+          model.validationMessages.postResetUrl !== "" &&
+          model.validationMessages.postResetUrl !== undefined
+        ) {
+          model.validationMessages.postResetUrl +=
+            ERROR_MESSAGES.INVALID_RESETPASS_LENTGH;
+        } else {
+          model.validationMessages.postResetUrl =
+            ERROR_MESSAGES.INVALID_RESETPASS_LENTGH;
+        }
       }
-    }
 
-    const isPostResetUrlProtocol = await isCorrectProtocol(postUrlValidator);
-    if (!isPostResetUrlProtocol) {
-      if (
-        model.validationMessages.postResetUrl !== "" &&
-        model.validationMessages.postResetUrl !== undefined
-      ) {
-        model.validationMessages.postResetUrl +=
-          ERROR_MESSAGES.INVALID_RESETPASS_PROTOCOL;
-      } else {
-        model.validationMessages.postResetUrl =
-          ERROR_MESSAGES.INVALID_RESETPASS_PROTOCOL;
+      const isPostResetUrlProtocol = await isCorrectProtocol(postUrlValidator);
+      if (!isPostResetUrlProtocol) {
+        if (
+          model.validationMessages.postResetUrl !== "" &&
+          model.validationMessages.postResetUrl !== undefined
+        ) {
+          model.validationMessages.postResetUrl +=
+            ERROR_MESSAGES.INVALID_RESETPASS_PROTOCOL;
+        } else {
+          model.validationMessages.postResetUrl =
+            ERROR_MESSAGES.INVALID_RESETPASS_PROTOCOL;
+        }
       }
     }
 
@@ -277,129 +282,144 @@ const validate = async (req, currentService) => {
       model.validationMessages.clientId = ERROR_MESSAGES.CLIENT_ID_UNAVAILABLE;
     }
 
-    if (!model.service.redirectUris || !model.service.redirectUris.length > 0) {
-      model.validationMessages.redirect_uris =
-        ERROR_MESSAGES.MISSING_REDIRECT_URL;
-    } else if (model.service.redirectUris.length > 0) {
-      await Promise.all(
-        model.service.redirectUris.map(async (x) => {
-          const redirecturlValidator = new UrlValidator(x);
-          const isRCorrectLength = await isCorrectLength(redirecturlValidator);
-          const isCorrectUtl = await isValidUrl(redirecturlValidator);
-          if (!isRCorrectLength) {
-            if (
-              model.validationMessages.redirect_uris !== "" &&
-              model.validationMessages.redirect_uris !== undefined
-            ) {
-              model.validationMessages.redirect_uris +=
-                ERROR_MESSAGES.INVALID_REDIRECT_LENTGH;
-            } else {
-              model.validationMessages.redirect_uris =
-                ERROR_MESSAGES.INVALID_REDIRECT_LENTGH;
-            }
-          }
-          if (!isCorrectUtl) {
-            if (
-              model.validationMessages.redirect_uris !== "" &&
-              model.validationMessages.redirect_uris !== undefined
-            ) {
-              model.validationMessages.redirect_uris +=
-                ERROR_MESSAGES.INVALID_REDIRECT_CHARACTERS;
-            } else {
-              model.validationMessages.redirect_uris =
-                ERROR_MESSAGES.INVALID_REDIRECT_CHARACTERS;
-            }
-          }
-
-          const isValidProtocol = await isCorrectProtocol(redirecturlValidator);
-          if (!isValidProtocol) {
-            if (
-              model.validationMessages.redirect_uris !== "" &&
-              model.validationMessages.redirect_uris !== undefined
-            ) {
-              model.validationMessages.redirect_uris +=
-                ERROR_MESSAGES.INVALID_REDIRECT_PROTOCOL;
-            } else {
-              model.validationMessages.redirect_uris =
-                ERROR_MESSAGES.INVALID_REDIRECT_PROTOCOL;
-            }
-          }
-        }),
-      );
+    // Only validate redirectUris if they were part of the submitted changes.
+    // When only hideService changed, redirectUris is not in the session and
+    // should not be re-validated.
+    if (serviceConfigurationChanges.redirectUris !== undefined) {
       if (
-        model.service.redirectUris.some(
-          (value, i) => model.service.redirectUris.indexOf(value) !== i,
-        )
+        !model.service.redirectUris ||
+        !model.service.redirectUris.length > 0
       ) {
         model.validationMessages.redirect_uris =
-          ERROR_MESSAGES.REDIRECT_URLS_NOT_UNIQUE;
+          ERROR_MESSAGES.MISSING_REDIRECT_URL;
+      } else if (model.service.redirectUris.length > 0) {
+        await Promise.all(
+          model.service.redirectUris.map(async (x) => {
+            const redirecturlValidator = new UrlValidator(x);
+            const isRCorrectLength =
+              await isCorrectLength(redirecturlValidator);
+            const isCorrectUtl = await isValidUrl(redirecturlValidator);
+            if (!isRCorrectLength) {
+              if (
+                model.validationMessages.redirect_uris !== "" &&
+                model.validationMessages.redirect_uris !== undefined
+              ) {
+                model.validationMessages.redirect_uris +=
+                  ERROR_MESSAGES.INVALID_REDIRECT_LENTGH;
+              } else {
+                model.validationMessages.redirect_uris =
+                  ERROR_MESSAGES.INVALID_REDIRECT_LENTGH;
+              }
+            }
+            if (!isCorrectUtl) {
+              if (
+                model.validationMessages.redirect_uris !== "" &&
+                model.validationMessages.redirect_uris !== undefined
+              ) {
+                model.validationMessages.redirect_uris +=
+                  ERROR_MESSAGES.INVALID_REDIRECT_CHARACTERS;
+              } else {
+                model.validationMessages.redirect_uris =
+                  ERROR_MESSAGES.INVALID_REDIRECT_CHARACTERS;
+              }
+            }
+
+            const isValidProtocol =
+              await isCorrectProtocol(redirecturlValidator);
+            if (!isValidProtocol) {
+              if (
+                model.validationMessages.redirect_uris !== "" &&
+                model.validationMessages.redirect_uris !== undefined
+              ) {
+                model.validationMessages.redirect_uris +=
+                  ERROR_MESSAGES.INVALID_REDIRECT_PROTOCOL;
+              } else {
+                model.validationMessages.redirect_uris =
+                  ERROR_MESSAGES.INVALID_REDIRECT_PROTOCOL;
+              }
+            }
+          }),
+        );
+        if (
+          model.service.redirectUris.some(
+            (value, i) => model.service.redirectUris.indexOf(value) !== i,
+          )
+        ) {
+          model.validationMessages.redirect_uris =
+            ERROR_MESSAGES.REDIRECT_URLS_NOT_UNIQUE;
+        }
       }
     }
 
-    if (
-      !model.service.postLogoutRedirectUris ||
-      !model.service.postLogoutRedirectUris.length > 0
-    ) {
-      model.validationMessages.post_logout_redirect_uris =
-        ERROR_MESSAGES.MISSING_POST_LOGOUT_URL;
-    } else if (model.service.postLogoutRedirectUris.length > 0) {
-      await Promise.all(
-        model.service.postLogoutRedirectUris.map(async (x) => {
-          const postRedirecturlValidator = new UrlValidator(x);
-          const isRDCorrectLength = await isCorrectLength(
-            postRedirecturlValidator,
-          );
-          const estCorrect = await isValidUrl(postRedirecturlValidator);
-          if (!isRDCorrectLength) {
-            if (
-              model.validationMessages.post_logout_redirect_uris !== "" &&
-              model.validationMessages.post_logout_redirect_uris !== undefined
-            ) {
-              model.validationMessages.post_logout_redirect_uris +=
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_LENTGH;
-            } else {
-              model.validationMessages.post_logout_redirect_uris =
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_LENTGH;
-            }
-          }
-          if (estCorrect !== true) {
-            if (
-              model.validationMessages.post_logout_redirect_uris !== "" &&
-              model.validationMessages.post_logout_redirect_uris !== undefined
-            ) {
-              model.validationMessages.post_logout_redirect_uris +=
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_CHARACTERS;
-            } else {
-              model.validationMessages.post_logout_redirect_uris =
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_CHARACTERS;
-            }
-          }
-
-          const testRDProtocol = await isCorrectProtocol(
-            postRedirecturlValidator,
-          );
-          if (!testRDProtocol) {
-            if (
-              model.validationMessages.post_logout_redirect_uris !== "" &&
-              model.validationMessages.post_logout_redirect_uris !== undefined
-            ) {
-              model.validationMessages.post_logout_redirect_uris +=
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_PROTOCOL;
-            } else {
-              model.validationMessages.post_logout_redirect_uris =
-                ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_PROTOCOL;
-            }
-          }
-        }),
-      );
+    // Only validate postLogoutRedirectUris if they were part of the submitted changes.
+    // When only hideService changed, postLogoutRedirectUris is not in the session and
+    // should not be re-validated.
+    if (serviceConfigurationChanges.postLogoutRedirectUris !== undefined) {
       if (
-        model.service.postLogoutRedirectUris.some(
-          (value, i) =>
-            model.service.postLogoutRedirectUris.indexOf(value) !== i,
-        )
+        !model.service.postLogoutRedirectUris ||
+        !model.service.postLogoutRedirectUris.length > 0
       ) {
         model.validationMessages.post_logout_redirect_uris =
-          ERROR_MESSAGES.POST_LOGOUT_URL_NOT_UNIQUE;
+          ERROR_MESSAGES.MISSING_POST_LOGOUT_URL;
+      } else if (model.service.postLogoutRedirectUris.length > 0) {
+        await Promise.all(
+          model.service.postLogoutRedirectUris.map(async (x) => {
+            const postRedirecturlValidator = new UrlValidator(x);
+            const isRDCorrectLength = await isCorrectLength(
+              postRedirecturlValidator,
+            );
+            const estCorrect = await isValidUrl(postRedirecturlValidator);
+            if (!isRDCorrectLength) {
+              if (
+                model.validationMessages.post_logout_redirect_uris !== "" &&
+                model.validationMessages.post_logout_redirect_uris !== undefined
+              ) {
+                model.validationMessages.post_logout_redirect_uris +=
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_LENTGH;
+              } else {
+                model.validationMessages.post_logout_redirect_uris =
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_LENTGH;
+              }
+            }
+            if (estCorrect !== true) {
+              if (
+                model.validationMessages.post_logout_redirect_uris !== "" &&
+                model.validationMessages.post_logout_redirect_uris !== undefined
+              ) {
+                model.validationMessages.post_logout_redirect_uris +=
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_CHARACTERS;
+              } else {
+                model.validationMessages.post_logout_redirect_uris =
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_CHARACTERS;
+              }
+            }
+
+            const testRDProtocol = await isCorrectProtocol(
+              postRedirecturlValidator,
+            );
+            if (!testRDProtocol) {
+              if (
+                model.validationMessages.post_logout_redirect_uris !== "" &&
+                model.validationMessages.post_logout_redirect_uris !== undefined
+              ) {
+                model.validationMessages.post_logout_redirect_uris +=
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_PROTOCOL;
+              } else {
+                model.validationMessages.post_logout_redirect_uris =
+                  ERROR_MESSAGES.INVALID_LOGOUT_REDIRECT_PROTOCOL;
+              }
+            }
+          }),
+        );
+        if (
+          model.service.postLogoutRedirectUris.some(
+            (value, i) =>
+              model.service.postLogoutRedirectUris.indexOf(value) !== i,
+          )
+        ) {
+          model.validationMessages.post_logout_redirect_uris =
+            ERROR_MESSAGES.POST_LOGOUT_URL_NOT_UNIQUE;
+        }
       }
     }
 
@@ -564,11 +584,15 @@ const postConfirmServiceConfig = async (req, res) => {
       apiSecret: model.service.apiSecret
         ? encrypt(model.service.apiSecret)
         : model.service.apiSecret,
-      // If tokenEndpointAuthMethod isn't 'client_secret_post', store NULL in the DB.
+      // If tokenEndpointAuthMethod was changed and isn't 'client_secret_post', store NULL in the DB.
+      // When tokenEndpointAuthMethod is undefined (not changed), pass undefined so the infrastructure
+      // wrapper's '!== undefined' guard correctly skips it and avoids overwriting the stored value.
       tokenEndpointAuthMethod:
-        model.service.tokenEndpointAuthMethod === CLIENT_SECRET_POST
-          ? CLIENT_SECRET_POST
-          : null,
+        model.service.tokenEndpointAuthMethod !== undefined
+          ? model.service.tokenEndpointAuthMethod === CLIENT_SECRET_POST
+            ? CLIENT_SECRET_POST
+            : null
+          : undefined,
     };
 
     await updateService(req.params.sid, updatedService);

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -595,7 +595,15 @@ const postConfirmServiceConfig = async (req, res) => {
           : undefined,
     };
 
-    await updateService(req.params.sid, updatedService);
+    // Only call updateService if at least one OIDC field has a value to persist.
+    // When only hideService was changed all values in updatedService will be
+    // undefined, and calling the API with an empty update object causes a 500.
+    const hasOidcChanges = Object.values(updatedService).some(
+      (v) => v !== undefined,
+    );
+    if (hasOidcChanges) {
+      await updateService(req.params.sid, updatedService);
+    }
 
     // Apply Hide Service changes if the checkbox state was changed.
     const hideServiceChange =

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -618,17 +618,17 @@ const postConfirmServiceConfig = async (req, res) => {
         updateServiceParam({
           serviceId,
           paramName: "hideApprover",
-          value: hiddenValue,
+          paramValue: hiddenValue,
         }),
         updateServiceParam({
           serviceId,
           paramName: "hideSupport",
-          value: hiddenValue,
+          paramValue: hiddenValue,
         }),
         updateServiceParam({
           serviceId,
           paramName: "helpHidden",
-          value: hiddenValue,
+          paramValue: hiddenValue,
         }),
       ]);
 

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -1,7 +1,10 @@
 const niceware = require("niceware");
 const UrlValidator = require("login.dfe.validation/src/urlValidator");
 const { updateService } = require("../../infrastructure/utils/services");
-const { getServiceRaw } = require("login.dfe.api-client/services");
+const {
+  getServiceRaw,
+  updateServiceParam,
+} = require("login.dfe.api-client/services");
 const logger = require("../../infrastructure/logger");
 const {
   getUserServiceRoles,
@@ -577,17 +580,19 @@ const postConfirmServiceConfig = async (req, res) => {
       hideServiceChange &&
       hideServiceChange.newValue !== hideServiceChange.oldValue
     ) {
-      // TODO: implement updateServiceParam in login.dfe.api-client
-      // const hiddenValue = hideServiceChange.newValue ? "true" : "false";
-      // const serviceId = req.params.sid;
-      // await updateServiceParam(serviceId, 'hideApprover', hiddenValue);
-      // await updateServiceParam(serviceId, 'hideSupport', hiddenValue);
-      // await updateServiceParam(serviceId, 'helpHidden', hiddenValue);
+      const hiddenValue = hideServiceChange.newValue ? "true" : "false";
+      const serviceId = req.params.sid;
+      await Promise.all([
+        updateServiceParam(serviceId, "hideApprover", hiddenValue),
+        updateServiceParam(serviceId, "hideSupport", hiddenValue),
+        updateServiceParam(serviceId, "helpHidden", hiddenValue),
+      ]);
 
       if (hideServiceChange.isIdOnlyService) {
-        // TODO: implement isHiddenService update in login.dfe.api-client
-        // const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
-        // await updateService(req.params.sid, { isHiddenService: isHiddenServiceValue });
+        const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
+        await updateService(req.params.sid, {
+          isHiddenService: isHiddenServiceValue,
+        });
       }
     }
 

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -614,7 +614,7 @@ const postConfirmServiceConfig = async (req, res) => {
     ) {
       const hiddenValue = hideServiceChange.newValue ? "true" : "false";
       const serviceId = req.params.sid;
-      await Promise.all([
+      const paramUpdates = [
         updateServiceParam({
           serviceId,
           paramName: "hideApprover",
@@ -630,7 +630,18 @@ const postConfirmServiceConfig = async (req, res) => {
           paramName: "helpHidden",
           paramValue: hiddenValue,
         }),
-      ]);
+      ];
+      // For id-only services, isHiddenService on the service record must also
+      // be kept in sync with the params so that downstream policy checks that
+      // read isHiddenService directly reflect the correct hidden state.
+      if (hideServiceChange.isIdOnlyService) {
+        paramUpdates.push(
+          updateService(serviceId, {
+            isHiddenService: hideServiceChange.newValue,
+          }),
+        );
+      }
+      await Promise.all(paramUpdates);
     }
 
     logger.audit(`${req.user.email} updated service configuration`, {

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -615,9 +615,21 @@ const postConfirmServiceConfig = async (req, res) => {
       const hiddenValue = hideServiceChange.newValue ? "true" : "false";
       const serviceId = req.params.sid;
       await Promise.all([
-        updateServiceParam(serviceId, "hideApprover", hiddenValue),
-        updateServiceParam(serviceId, "hideSupport", hiddenValue),
-        updateServiceParam(serviceId, "helpHidden", hiddenValue),
+        updateServiceParam({
+          serviceId,
+          paramName: "hideApprover",
+          value: hiddenValue,
+        }),
+        updateServiceParam({
+          serviceId,
+          paramName: "hideSupport",
+          value: hiddenValue,
+        }),
+        updateServiceParam({
+          serviceId,
+          paramName: "helpHidden",
+          value: hiddenValue,
+        }),
       ]);
 
       if (hideServiceChange.isIdOnlyService) {

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -631,13 +631,6 @@ const postConfirmServiceConfig = async (req, res) => {
           paramValue: hiddenValue,
         }),
       ]);
-
-      if (hideServiceChange.isIdOnlyService) {
-        const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
-        await updateService(req.params.sid, {
-          isHiddenService: isHiddenServiceValue,
-        });
-      }
     }
 
     logger.audit(`${req.user.email} updated service configuration`, {

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -170,48 +170,54 @@ const validate = async (req, currentService) => {
       model.service.redirectUris =
         serviceConfigurationChanges.redirectUris.oldValue;
     }
-    const urlValidator = new UrlValidator(serviceHome);
-    const lengthResult = await isCorrectLength(urlValidator);
-    if (serviceHome !== null && !lengthResult) {
-      if (
-        model.validationMessages.serviceHome !== "" &&
-        model.validationMessages.serviceHome !== undefined
-      ) {
-        model.validationMessages.serviceHome +=
-          ERROR_MESSAGES.INVALID_HOME_LENTGH;
-      } else {
-        model.validationMessages.serviceHome =
-          ERROR_MESSAGES.INVALID_HOME_LENTGH;
-      }
-    }
-    const validUrl = await isValidUrl(urlValidator);
-    if (serviceHome !== null && !validUrl) {
-      if (serviceHome !== "") {
+    // Only validate serviceHome if it was part of the submitted changes.
+    // When only hideService changed, serviceHome is not in the session and
+    // should not be re-validated.
+    if (serviceHome !== undefined) {
+      const urlValidator = new UrlValidator(serviceHome);
+      const lengthResult = await isCorrectLength(urlValidator);
+      if (serviceHome !== null && !lengthResult) {
         if (
           model.validationMessages.serviceHome !== "" &&
           model.validationMessages.serviceHome !== undefined
         ) {
           model.validationMessages.serviceHome +=
-            ERROR_MESSAGES.INVALID_HOME_CHARACTERS;
+            ERROR_MESSAGES.INVALID_HOME_LENTGH;
         } else {
           model.validationMessages.serviceHome =
-            ERROR_MESSAGES.INVALID_HOME_CHARACTERS;
+            ERROR_MESSAGES.INVALID_HOME_LENTGH;
         }
-      } else {
-        model.validationMessages.serviceHome = ERROR_MESSAGES.INVALID_HOME_URL;
       }
-    }
-    const validProtocol = await isCorrectProtocol(urlValidator);
-    if (!validProtocol) {
-      if (
-        model.validationMessages.serviceHome !== "" &&
-        model.validationMessages.serviceHome !== undefined
-      ) {
-        model.validationMessages.serviceHome +=
-          ERROR_MESSAGES.INVALID_HOME_PROTOCOL;
-      } else {
-        model.validationMessages.serviceHome =
-          ERROR_MESSAGES.INVALID_HOME_PROTOCOL;
+      const validUrl = await isValidUrl(urlValidator);
+      if (serviceHome !== null && !validUrl) {
+        if (serviceHome !== "") {
+          if (
+            model.validationMessages.serviceHome !== "" &&
+            model.validationMessages.serviceHome !== undefined
+          ) {
+            model.validationMessages.serviceHome +=
+              ERROR_MESSAGES.INVALID_HOME_CHARACTERS;
+          } else {
+            model.validationMessages.serviceHome =
+              ERROR_MESSAGES.INVALID_HOME_CHARACTERS;
+          }
+        } else {
+          model.validationMessages.serviceHome =
+            ERROR_MESSAGES.INVALID_HOME_URL;
+        }
+      }
+      const validProtocol = await isCorrectProtocol(urlValidator);
+      if (!validProtocol) {
+        if (
+          model.validationMessages.serviceHome !== "" &&
+          model.validationMessages.serviceHome !== undefined
+        ) {
+          model.validationMessages.serviceHome +=
+            ERROR_MESSAGES.INVALID_HOME_PROTOCOL;
+        } else {
+          model.validationMessages.serviceHome =
+            ERROR_MESSAGES.INVALID_HOME_PROTOCOL;
+        }
       }
     }
 
@@ -447,8 +453,19 @@ const getConfirmServiceConfig = async (req, res) => {
       req.session.serviceConfigurationChanges[sid]?.authFlowType;
     const serviceConfigChanges = req.session.serviceConfigurationChanges[sid];
 
+    // Extract hideService before building the standard OIDC changes summary.
+    const hideServiceChange = serviceConfigChanges?.hideService;
+    const hideServiceChanged = !!(
+      hideServiceChange &&
+      hideServiceChange.newValue !== hideServiceChange.oldValue
+    );
+    const hideService = hideServiceChange?.newValue;
+
     const changedServiceParams = { ...serviceConfigChanges };
     delete changedServiceParams.authFlowType;
+    // Exclude hideService from the standard changes summary — it is displayed
+    // as a dedicated warning message in the template instead.
+    delete changedServiceParams.hideService;
 
     const serviceChanges = createFlattenedMappedServiceConfigChanges(
       changedServiceParams,
@@ -478,6 +495,8 @@ const getConfirmServiceConfig = async (req, res) => {
       userRoles: manageRolesForService,
       currentNavigation: "configuration",
       serviceChanges: fixedServiceChanges,
+      hideService,
+      hideServiceChanged,
     });
   } catch (error) {
     throw new Error(error);
@@ -550,6 +569,28 @@ const postConfirmServiceConfig = async (req, res) => {
     };
 
     await updateService(req.params.sid, updatedService);
+
+    // Apply Hide Service changes if the checkbox state was changed.
+    const hideServiceChange =
+      req.session.serviceConfigurationChanges[req.params.sid]?.hideService;
+    if (
+      hideServiceChange &&
+      hideServiceChange.newValue !== hideServiceChange.oldValue
+    ) {
+      const hiddenValue = hideServiceChange.newValue ? "true" : "false";
+      const serviceId = req.params.sid;
+
+      // TODO: implement updateServiceParam in login.dfe.api-client
+      // await updateServiceParam(serviceId, 'hideApprover', hiddenValue);
+      // await updateServiceParam(serviceId, 'hideSupport', hiddenValue);
+      // await updateServiceParam(serviceId, 'helpHidden', hiddenValue);
+
+      if (hideServiceChange.isIdOnlyService) {
+        const isHiddenServiceValue = hideServiceChange.newValue ? 1 : 0;
+        // TODO: implement isHiddenService update in login.dfe.api-client
+        // await updateService(serviceId, { isHiddenService: isHiddenServiceValue });
+      }
+    }
 
     logger.audit(`${req.user.email} updated service configuration`, {
       type: "manage",

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -1,10 +1,10 @@
 const niceware = require("niceware");
 const UrlValidator = require("login.dfe.validation/src/urlValidator");
-const { updateService } = require("../../infrastructure/utils/services");
 const {
-  getServiceRaw,
-  updateServiceParam,
-} = require("login.dfe.api-client/services");
+  updateService,
+  upsertServiceParam,
+} = require("../../infrastructure/utils/services");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const logger = require("../../infrastructure/logger");
 const {
   getUserServiceRoles,
@@ -615,17 +615,17 @@ const postConfirmServiceConfig = async (req, res) => {
       const hiddenValue = hideServiceChange.newValue ? "true" : "false";
       const serviceId = req.params.sid;
       const paramUpdates = [
-        updateServiceParam({
+        upsertServiceParam({
           serviceId,
           paramName: "hideApprover",
           paramValue: hiddenValue,
         }),
-        updateServiceParam({
+        upsertServiceParam({
           serviceId,
           paramName: "hideSupport",
           paramValue: hiddenValue,
         }),
-        updateServiceParam({
+        upsertServiceParam({
           serviceId,
           paramName: "helpHidden",
           paramValue: hiddenValue,

--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -631,17 +631,6 @@ const postConfirmServiceConfig = async (req, res) => {
           paramValue: hiddenValue,
         }),
       ];
-      // For id-only services, isHiddenService on the service record must also
-      // be kept in sync with the params so that downstream policy checks that
-      // read isHiddenService directly reflect the correct hidden state.
-      if (hideServiceChange.isIdOnlyService) {
-        paramUpdates.push(
-          updateService(serviceId, {
-            // API requires integer 1/0, not boolean.
-            isHiddenService: hideServiceChange.newValue ? 1 : 0,
-          }),
-        );
-      }
       await Promise.all(paramUpdates);
     }
 

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -619,13 +619,10 @@ const postServiceConfig = async (req, res) => {
 
     if (Object.keys(model.validationMessages).length > 0) {
       model.csrfToken = req.csrfToken();
-      const sessionHideService =
-        req.session.serviceConfigurationChanges?.[req.params.sid]?.hideService
-          ?.newValue;
-      model.isServiceHidden =
-        sessionHideService !== undefined
-          ? sessionHideService
-          : serviceModels.isServiceHiddenFromDb;
+      // Use the submitted checkbox value so it is preserved on re-render.
+      // The session has not been updated yet at this point, so reading from
+      // it would give a stale value (or undefined on a first submission).
+      model.isServiceHidden = req.body.hideService === "yes";
       return res.render("services/views/serviceConfig", model);
     }
 

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -21,6 +21,13 @@ const {
   _unescape,
 } = require("./utils");
 const { decrypt } = require("login.dfe.api-client/encryption");
+const { updateService } = require("../../infrastructure/utils/services");
+
+// Normalise param values to a consistent boolean.
+// The support console stores integer 1/0, the PUT API stores boolean true/false,
+// and the manage UI stores string "true"/"false". All must be treated as equivalent.
+const isTruthyParam = (val) =>
+  val === true || val === 1 || val === "true" || val === "1";
 
 const buildServiceModelFromObject = (service, sessionService = {}) => {
   let tokenEndpointAuthMethod = null;
@@ -121,26 +128,24 @@ const buildCurrentServiceModel = async (req) => {
     const oldServiceConfigModel = buildServiceModelFromObject(service);
 
     const params = service.relyingParty?.params || {};
-    const isIdOnlyService = service.isIdOnlyService === true;
-    let isServiceHiddenFromDb;
-    if (isIdOnlyService) {
-      isServiceHiddenFromDb =
-        service.isHiddenService === true &&
-        params.hideApprover === "true" &&
-        params.hideSupport === "true" &&
-        params.helpHidden === "true";
-    } else {
-      isServiceHiddenFromDb =
-        params.hideApprover === "true" &&
-        params.hideSupport === "true" &&
-        params.helpHidden === "true";
-    }
+    const isIdOnlyService = isTruthyParam(service.isIdOnlyService);
+    // The "Hide Service" checkbox state is derived from ALL THREE params for
+    // both id-only and role-based services. isHiddenService is intentionally
+    // NOT used here: it is kept in sync separately on save (confirmServiceConfig)
+    // and must not override the individual param values.
+    const isServiceHiddenFromDb =
+      isTruthyParam(params.hideApprover) &&
+      isTruthyParam(params.hideSupport) &&
+      isTruthyParam(params.helpHidden);
 
     return {
       currentServiceModel,
       oldServiceConfigModel,
       isServiceHiddenFromDb,
       isIdOnlyService,
+      // The raw DB value is returned so getServiceConfig can detect inconsistencies
+      // and auto-correct isHiddenService without an extra API round-trip.
+      rawIsHiddenService: service.isHiddenService,
     };
   } catch (error) {
     throw new Error(`Could not build service model - ${error}`);
@@ -156,6 +161,24 @@ const getServiceConfig = async (req, res) => {
     }
     const manageRolesForService = await getUserServiceRoles(req);
     const serviceModel = await buildCurrentServiceModel(req);
+
+    // Scenarios 2–5: for id-only services, isHiddenService in the DB can be
+    // inconsistent with the three params (e.g. when created by the support
+    // console with integer 1/0 and then params were changed via PUT API).
+    // Downstream apps (support console, help/contact-us) read isHiddenService
+    // directly, so fix the inconsistency proactively when an admin views the
+    // service configuration page for the first time (not during an amend-changes
+    // round-trip, where the state may still be in-flight from a pending save).
+    if (
+      req.query?.action !== ACTIONS.AMEND_CHANGES &&
+      serviceModel.isIdOnlyService &&
+      isTruthyParam(serviceModel.rawIsHiddenService) !==
+        serviceModel.isServiceHiddenFromDb
+    ) {
+      await updateService(sid, {
+        isHiddenService: serviceModel.isServiceHiddenFromDb,
+      });
+    }
 
     // Determine whether the Hide Service checkbox should be pre-checked.
     // When amending changes, use the session-stored value; otherwise use the DB value.

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -22,6 +22,7 @@ const {
 } = require("./utils");
 const { decrypt } = require("login.dfe.api-client/encryption");
 const { updateService } = require("../../infrastructure/utils/services");
+const logger = require("../../infrastructure/logger");
 
 // Normalise param values to a consistent boolean.
 // The support console stores integer 1/0, the PUT API stores boolean true/false,
@@ -175,9 +176,17 @@ const getServiceConfig = async (req, res) => {
       isTruthyParam(serviceModel.rawIsHiddenService) !==
         serviceModel.isServiceHiddenFromDb
     ) {
-      await updateService(sid, {
-        isHiddenService: serviceModel.isServiceHiddenFromDb,
-      });
+      try {
+        await updateService(sid, {
+          // API requires integer 1/0, not boolean.
+          isHiddenService: serviceModel.isServiceHiddenFromDb ? 1 : 0,
+        });
+      } catch (syncError) {
+        // Best-effort correction — log but do not block page render.
+        logger.warn(
+          `Failed to auto-sync isHiddenService for service ${sid}: ${syncError}`,
+        );
+      }
     }
 
     // Determine whether the Hide Service checkbox should be pre-checked.

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -120,9 +120,27 @@ const buildCurrentServiceModel = async (req) => {
     );
     const oldServiceConfigModel = buildServiceModelFromObject(service);
 
+    const params = service.relyingParty?.params || {};
+    const isIdOnlyService = service.isIdOnlyService === true;
+    let isServiceHiddenFromDb;
+    if (isIdOnlyService) {
+      isServiceHiddenFromDb =
+        service.isHiddenService === true &&
+        params.hideApprover === "true" &&
+        params.hideSupport === "true" &&
+        params.helpHidden === "true";
+    } else {
+      isServiceHiddenFromDb =
+        params.hideApprover === "true" &&
+        params.hideSupport === "true" &&
+        params.helpHidden === "true";
+    }
+
     return {
       currentServiceModel,
       oldServiceConfigModel,
+      isServiceHiddenFromDb,
+      isIdOnlyService,
     };
   } catch (error) {
     throw new Error(`Could not build service model - ${error}`);
@@ -138,6 +156,16 @@ const getServiceConfig = async (req, res) => {
     }
     const manageRolesForService = await getUserServiceRoles(req);
     const serviceModel = await buildCurrentServiceModel(req);
+
+    // Determine whether the Hide Service checkbox should be pre-checked.
+    // When amending changes, use the session-stored value; otherwise use the DB value.
+    const sessionHideService =
+      req.session.serviceConfigurationChanges?.[sid]?.hideService?.newValue;
+    const isServiceHidden =
+      sessionHideService !== undefined
+        ? sessionHideService
+        : serviceModel.isServiceHiddenFromDb;
+
     return res.render("services/views/serviceConfig", {
       csrfToken: req.csrfToken(),
       service: serviceModel.currentServiceModel,
@@ -146,6 +174,7 @@ const getServiceConfig = async (req, res) => {
       serviceId: sid,
       userRoles: manageRolesForService,
       currentNavigation: "configuration",
+      isServiceHidden,
     });
   } catch (error) {
     throw new Error(error);
@@ -558,6 +587,13 @@ const postServiceConfig = async (req, res) => {
 
     if (Object.keys(model.validationMessages).length > 0) {
       model.csrfToken = req.csrfToken();
+      const sessionHideService =
+        req.session.serviceConfigurationChanges?.[req.params.sid]?.hideService
+          ?.newValue;
+      model.isServiceHidden =
+        sessionHideService !== undefined
+          ? sessionHideService
+          : serviceModels.isServiceHiddenFromDb;
       return res.render("services/views/serviceConfig", model);
     }
 
@@ -637,6 +673,18 @@ const postServiceConfig = async (req, res) => {
           undefined;
       }
     }
+
+    // Handle the Hide Service checkbox separately from OIDC config fields.
+    const newHideService = req.body.hideService === "yes";
+    const oldHideService = serviceModels.isServiceHiddenFromDb;
+    if (newHideService !== oldHideService) {
+      req.session.serviceConfigurationChanges[sid].hideService = {
+        oldValue: oldHideService,
+        newValue: newHideService,
+        isIdOnlyService: serviceModels.isIdOnlyService,
+      };
+    }
+
     return res.redirect("review-service-configuration#");
   } catch (error) {
     throw new Error(error);

--- a/src/app/services/views/confirmServiceConfig.ejs
+++ b/src/app/services/views/confirmServiceConfig.ejs
@@ -71,7 +71,7 @@
                 </div>
                 <% } %>
               <% }); %>
-            <% } else {%>
+            <% } else if (!locals.hideServiceChanged) {%>
               <div class="govuk-summary-list__row empty-state">
                 <dt class="govuk-summary-list__value govuk-visually-hidden empty-state">
                 </dt>
@@ -83,6 +83,20 @@
               </div>
               <% }%>
           </dl>
+
+          <% if (locals.hideServiceChanged) { %>
+            <div class="govuk-warning-text" id="hide-service-change-warning">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-visually-hidden">Warning</span>
+                <% if (locals.hideService) { %>
+                  This service will be hidden from users, approvers, support, and the help page.
+                <% } else { %>
+                  This service will be revealed and visible in support, help, and to approvers.
+                <% } %>
+              </strong>
+            </div>
+          <% } %>
         </div>
       </div>
       <div class="govuk-warning-text" id="service-config-changes-warning-text">
@@ -93,7 +107,7 @@
         </strong>
       </div>
       <div class="govuk-button-group govuk-!-margin-top-3">
-        <button type="submit" class="govuk-button" data-module="govuk-button" id="service-config-changes-save-button" <%= (locals.serviceChanges && locals.serviceChanges.length === 0) ? 'disabled' : '' %> >Save</button>
+        <button type="submit" class="govuk-button" data-module="govuk-button" id="service-config-changes-save-button" <%= (locals.serviceChanges && locals.serviceChanges.length === 0 && !locals.hideServiceChanged) ? 'disabled' : '' %> >Save</button>
         <a href="<%= locals.cancelLink %>" class="govuk-button govuk-button--secondary" id="service-config-changes-cancel-button">Cancel</a>
     </div>
   </form>

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -185,6 +185,18 @@
                         <input class="form-control govuk-input" id="postResetUrl" name="postResetUrl" type="text"
                             value="<%-locals.service.postResetUrl%>" />
                     </div>
+
+                    <div class="govuk-form-group" id="hideService-form-group">
+                        <h2 class="govuk-heading-m">Hide Service</h2>
+                        <div class="govuk-checkboxes" id="hideService-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="hideService" name="hideService" type="checkbox" value="yes" <%= locals.isServiceHidden ? 'checked' : '' %>>
+                                <label class="govuk-label govuk-checkboxes__label" for="hideService">
+                                    Hide this service from users, approvers, support, and the help page
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                 </fieldset>
 
                 <hr class="govuk-section-break govuk-section-break--visible">

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -25,6 +25,7 @@
             id="<%=sectionId%>"
             name="<%=sectionId%>"
             type="password"
+            autocomplete="off"
             readonly="readonly"
             value="<%-dataValues%>" />
         </div>
@@ -300,14 +301,14 @@
                                     <input id="response_types-code" class ="govuk-checkboxes__input" type="checkbox"
                                     name="response_types" value="code" <%=
                                     (locals.service.responseTypes.indexOf('code') !== -1) ? 'checked' : ''%>>
-                                    <label class="govuk-label govuk-checkboxes__label" for="code" id="code-label">code</label>
+                                    <label class="govuk-label govuk-checkboxes__label" for="response_types-code" id="code-label">code</label>
                                 </div>
 
                                 <div class="multiple-choice govuk-checkboxes__item">
                                     <input id="response_types-id_token" class = "govuk-checkboxes__input" type="checkbox"
                                     name="response_types" value="id_token" <%=
                                     (locals.service.responseTypes.indexOf('id_token') !== -1) ? 'checked' : ''%>>
-                                    <label class="govuk-label govuk-checkboxes__label" for="id_token" id="id_token-label">
+                                    <label class="govuk-label govuk-checkboxes__label" for="response_types-id_token" id="id_token-label">
                                         id_token
                                     </label>
                                 </div>

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -161,7 +161,7 @@
                         <%-locals.validationMessages.serviceHome %>
                         </p>
                         <% } %>
-                        <input type="url" class="form-control  govuk-input" id="serviceHome" name="serviceHome" pattern="https://.\<>*" value='<%- locals.service.serviceHome %>' />
+                        <input type="url" class="form-control  govuk-input" id="serviceHome" name="serviceHome" pattern="https://[^<>]*" value='<%- locals.service.serviceHome %>' />
                     
                     </div>
 

--- a/src/infrastructure/utils/services.js
+++ b/src/infrastructure/utils/services.js
@@ -44,6 +44,9 @@ const updateService = async (serviceId, serviceDetails) => {
     updatedServiceDetails.tokenEndpointAuthMethod =
       serviceDetails.tokenEndpointAuthMethod;
   }
+  if (serviceDetails.isHiddenService !== undefined) {
+    updatedServiceDetails.isHiddenService = serviceDetails.isHiddenService;
+  }
 
   await updateServiceApiClient({
     serviceId: serviceId,

--- a/src/infrastructure/utils/services.js
+++ b/src/infrastructure/utils/services.js
@@ -1,5 +1,6 @@
 const {
   updateService: updateServiceApiClient,
+  updateServiceParam,
 } = require("login.dfe.api-client/services");
 
 const updateService = async (serviceId, serviceDetails) => {
@@ -54,6 +55,41 @@ const updateService = async (serviceId, serviceDetails) => {
   });
 };
 
+// updateServiceParam uses PUT which only updates existing params. This helper
+// falls back to POST when the param doesn't exist (404), because the api-client
+// does not export the `./api` subpath needed to call POST directly at the top level.
+const upsertServiceParam = async ({ serviceId, paramName, paramValue }) => {
+  try {
+    await updateServiceParam({ serviceId, paramName, paramValue });
+  } catch (err) {
+    if (err?.statusCode === 404) {
+      // Lazy-load api-client internals via direct file path to bypass the package's
+      // `exports` restriction — `./api` is intentionally not a public export.
+      const {
+        getApiClient,
+        ApiName,
+      } = require("../../../node_modules/login.dfe.api-client/dist/api/index.js");
+      const {
+        RequestMethod,
+      } = require("../../../node_modules/login.dfe.api-client/dist/api/common/ApiClient.js");
+      const client = getApiClient(ApiName.Applications);
+      const response = await client.requestRaw(
+        RequestMethod.POST,
+        `/services/${serviceId}/params`,
+        { jsonBody: { paramName, paramValue } },
+      );
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(
+          `Failed to create service param ${paramName}: HTTP ${response.status}`,
+        );
+      }
+    } else {
+      throw err;
+    }
+  }
+};
+
 module.exports = {
   updateService,
+  upsertServiceParam,
 };

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -915,7 +915,7 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).not.toHaveBeenCalled();
     });
 
-    it("also calls updateService with isHiddenService for id-only services", async () => {
+    it("calls updateService with isHiddenService: 1 and updateServiceParam three times with 'true' when hiding for id-only services", async () => {
       req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
         oldValue: false,
         newValue: true,
@@ -925,10 +925,58 @@ describe("when confirming service config changes in the review page", () => {
       await postConfirmServiceConfig(req, res);
 
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideApprover",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideSupport",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "helpHidden",
+        "true",
+      );
       expect(updateService).toHaveBeenCalledWith(
         expect.objectContaining({
           serviceId: "service1",
           update: expect.objectContaining({ isHiddenService: 1 }),
+        }),
+      );
+    });
+
+    it("calls updateService with isHiddenService: 0 and updateServiceParam three times with 'false' when revealing for id-only services", async () => {
+      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
+        oldValue: true,
+        newValue: false,
+        isIdOnlyService: true,
+      });
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideApprover",
+        "false",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideSupport",
+        "false",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "helpHidden",
+        "false",
+      );
+      expect(updateService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: "service1",
+          update: expect.objectContaining({ isHiddenService: 0 }),
         }),
       );
     });

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -976,11 +976,6 @@ describe("when confirming service config changes in the review page", () => {
         paramName: "helpHidden",
         paramValue: "true",
       });
-      // isHiddenService on the service record must also be set for id-only services
-      expect(updateService).toHaveBeenCalledWith({
-        serviceId: "service1",
-        update: { isHiddenService: 1 },
-      });
     });
 
     it("calls updateServiceParam three times with 'false' when revealing for id-only services", async () => {
@@ -1008,27 +1003,29 @@ describe("when confirming service config changes in the review page", () => {
         paramName: "helpHidden",
         paramValue: "false",
       });
-      // isHiddenService on the service record must also be cleared for id-only services
-      expect(updateService).toHaveBeenCalledWith({
-        serviceId: "service1",
-        update: { isHiddenService: 0 },
-      });
     });
 
-    it("does not call updateService with isHiddenService for role-based services", async () => {
-      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
-        oldValue: false,
-        newValue: true,
-        isIdOnlyService: false,
-      });
+    it.each([
+      { label: "role-based", isIdOnlyService: false },
+      { label: "id-only", isIdOnlyService: true },
+    ])(
+      "does not call updateService with isHiddenService for $label services",
+      async ({ isIdOnlyService }) => {
+        req.session.serviceConfigurationChanges["service1"] =
+          hideServiceSession({
+            oldValue: false,
+            newValue: true,
+            isIdOnlyService,
+          });
 
-      await postConfirmServiceConfig(req, res);
+        await postConfirmServiceConfig(req, res);
 
-      expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      const allUpdateServiceCalls = updateService.mock.calls;
-      allUpdateServiceCalls.forEach(([params]) => {
-        expect(params.update).not.toHaveProperty("isHiddenService");
-      });
-    });
+        expect(updateServiceParam).toHaveBeenCalledTimes(3);
+        const allUpdateServiceCalls = updateService.mock.calls;
+        allUpdateServiceCalls.forEach(([params]) => {
+          expect(params.update).not.toHaveProperty("isHiddenService");
+        });
+      },
+    );
   });
 });

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -14,6 +14,7 @@ jest.mock("./../../../src/infrastructure/logger", () =>
 jest.mock("login.dfe.api-client/services", () => ({
   getServiceRaw: jest.fn(),
   updateService: jest.fn(),
+  updateServiceParam: jest.fn(),
 }));
 
 jest.mock("../../../src/app/services/utils", () => {
@@ -53,6 +54,7 @@ const {
 const {
   getServiceRaw,
   updateService,
+  updateServiceParam,
 } = require("login.dfe.api-client/services");
 
 const res = getResponseMock();
@@ -109,6 +111,7 @@ describe("when confirming service config changes in the review page", () => {
     checkClientId.mockReset();
 
     updateService.mockReset();
+    updateServiceParam.mockReset();
     getServiceRaw.mockReset();
     getServiceRaw
       .mockReturnValueOnce({ ...currentServiceInfo })
@@ -831,5 +834,119 @@ describe("when confirming service config changes in the review page", () => {
       "Your changes to service configuration for service one have been saved.",
     );
     expect(res.redirect).toHaveBeenCalledWith("/services/service1");
+  });
+
+  describe("Hide Service checkbox", () => {
+    const hideServiceSession = (hideServiceOverrides = {}) => ({
+      redirectUris: {
+        oldValue: ["https://example.com"],
+        newValue: ["https://example.com"],
+      },
+      postLogoutRedirectUris: {
+        oldValue: ["https://example.com"],
+        newValue: ["https://example.com"],
+      },
+      hideService: {
+        oldValue: false,
+        newValue: true,
+        isIdOnlyService: false,
+        ...hideServiceOverrides,
+      },
+    });
+
+    it("calls updateServiceParam for all three params with 'true' when checkbox is checked", async () => {
+      req.session.serviceConfigurationChanges["service1"] =
+        hideServiceSession();
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideApprover",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideSupport",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "helpHidden",
+        "true",
+      );
+    });
+
+    it("calls updateServiceParam with 'false' for all three params when checkbox is unchecked", async () => {
+      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
+        oldValue: true,
+        newValue: false,
+      });
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideApprover",
+        "false",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideSupport",
+        "false",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "helpHidden",
+        "false",
+      );
+    });
+
+    it("does not call updateServiceParam when the checkbox value has not changed", async () => {
+      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
+        oldValue: true,
+        newValue: true,
+      });
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).not.toHaveBeenCalled();
+    });
+
+    it("also calls updateService with isHiddenService for id-only services", async () => {
+      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
+        oldValue: false,
+        newValue: true,
+        isIdOnlyService: true,
+      });
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: "service1",
+          update: expect.objectContaining({ isHiddenService: 1 }),
+        }),
+      );
+    });
+
+    it("does not call updateService with isHiddenService for role-based services", async () => {
+      req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
+        oldValue: false,
+        newValue: true,
+        isIdOnlyService: false,
+      });
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      const allUpdateServiceCalls = updateService.mock.calls;
+      allUpdateServiceCalls.forEach(([params]) => {
+        expect(params.update).not.toHaveProperty("isHiddenService");
+      });
+    });
   });
 });

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -951,7 +951,7 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).not.toHaveBeenCalled();
     });
 
-    it("calls updateService with isHiddenService: 1 and updateServiceParam three times with 'true' when hiding for id-only services", async () => {
+    it("calls updateServiceParam three times with 'true' when hiding for id-only services", async () => {
       req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
         oldValue: false,
         newValue: true,
@@ -976,15 +976,9 @@ describe("when confirming service config changes in the review page", () => {
         paramName: "helpHidden",
         paramValue: "true",
       });
-      expect(updateService).toHaveBeenCalledWith(
-        expect.objectContaining({
-          serviceId: "service1",
-          update: expect.objectContaining({ isHiddenService: 1 }),
-        }),
-      );
     });
 
-    it("calls updateService with isHiddenService: 0 and updateServiceParam three times with 'false' when revealing for id-only services", async () => {
+    it("calls updateServiceParam three times with 'false' when revealing for id-only services", async () => {
       req.session.serviceConfigurationChanges["service1"] = hideServiceSession({
         oldValue: true,
         newValue: false,
@@ -1009,12 +1003,6 @@ describe("when confirming service config changes in the review page", () => {
         paramName: "helpHidden",
         paramValue: "false",
       });
-      expect(updateService).toHaveBeenCalledWith(
-        expect.objectContaining({
-          serviceId: "service1",
-          update: expect.objectContaining({ isHiddenService: 0 }),
-        }),
-      );
     });
 
     it("does not call updateService with isHiddenService for role-based services", async () => {

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -872,21 +872,21 @@ describe("when confirming service config changes in the review page", () => {
       // empty update object causes the real API to return a 500.
       expect(updateService).not.toHaveBeenCalled();
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideApprover",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideSupport",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "helpHidden",
-        "true",
-      );
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideApprover",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideSupport",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "helpHidden",
+        value: "true",
+      });
       expect(res.redirect).toHaveBeenCalledWith("/services/service1");
     });
 
@@ -897,21 +897,21 @@ describe("when confirming service config changes in the review page", () => {
       await postConfirmServiceConfig(req, res);
 
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideApprover",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideSupport",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "helpHidden",
-        "true",
-      );
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideApprover",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideSupport",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "helpHidden",
+        value: "true",
+      });
     });
 
     it("calls updateServiceParam with 'false' for all three params when checkbox is unchecked", async () => {
@@ -923,21 +923,21 @@ describe("when confirming service config changes in the review page", () => {
       await postConfirmServiceConfig(req, res);
 
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideApprover",
-        "false",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideSupport",
-        "false",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "helpHidden",
-        "false",
-      );
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideApprover",
+        value: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideSupport",
+        value: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "helpHidden",
+        value: "false",
+      });
     });
 
     it("does not call updateServiceParam when the checkbox value has not changed", async () => {
@@ -961,21 +961,21 @@ describe("when confirming service config changes in the review page", () => {
       await postConfirmServiceConfig(req, res);
 
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideApprover",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideSupport",
-        "true",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "helpHidden",
-        "true",
-      );
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideApprover",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideSupport",
+        value: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "helpHidden",
+        value: "true",
+      });
       expect(updateService).toHaveBeenCalledWith(
         expect.objectContaining({
           serviceId: "service1",
@@ -994,21 +994,21 @@ describe("when confirming service config changes in the review page", () => {
       await postConfirmServiceConfig(req, res);
 
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideApprover",
-        "false",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "hideSupport",
-        "false",
-      );
-      expect(updateServiceParam).toHaveBeenCalledWith(
-        "service1",
-        "helpHidden",
-        "false",
-      );
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideApprover",
+        value: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "hideSupport",
+        value: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName: "helpHidden",
+        value: "false",
+      });
       expect(updateService).toHaveBeenCalledWith(
         expect.objectContaining({
           serviceId: "service1",

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -976,6 +976,11 @@ describe("when confirming service config changes in the review page", () => {
         paramName: "helpHidden",
         paramValue: "true",
       });
+      // isHiddenService on the service record must also be set for id-only services
+      expect(updateService).toHaveBeenCalledWith({
+        serviceId: "service1",
+        update: { isHiddenService: true },
+      });
     });
 
     it("calls updateServiceParam three times with 'false' when revealing for id-only services", async () => {
@@ -1002,6 +1007,11 @@ describe("when confirming service config changes in the review page", () => {
         serviceId: "service1",
         paramName: "helpHidden",
         paramValue: "false",
+      });
+      // isHiddenService on the service record must also be cleared for id-only services
+      expect(updateService).toHaveBeenCalledWith({
+        serviceId: "service1",
+        update: { isHiddenService: false },
       });
     });
 

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -868,6 +868,9 @@ describe("when confirming service config changes in the review page", () => {
 
       await postConfirmServiceConfig(req, res);
 
+      // The OIDC updateService API must NOT be called — calling it with an
+      // empty update object causes the real API to return a 500.
+      expect(updateService).not.toHaveBeenCalled();
       expect(updateServiceParam).toHaveBeenCalledTimes(3);
       expect(updateServiceParam).toHaveBeenCalledWith(
         "service1",

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -854,6 +854,39 @@ describe("when confirming service config changes in the review page", () => {
       },
     });
 
+    it("should not crash with 500 when only hideService is in session (no OIDC fields)", async () => {
+      // This is the real-world failing scenario: user only toggles Hide Service
+      // without changing any OIDC fields, so redirectUris / postLogoutRedirectUris
+      // are absent from the session.
+      req.session.serviceConfigurationChanges["service1"] = {
+        hideService: {
+          oldValue: false,
+          newValue: true,
+          isIdOnlyService: false,
+        },
+      };
+
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledTimes(3);
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideApprover",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "hideSupport",
+        "true",
+      );
+      expect(updateServiceParam).toHaveBeenCalledWith(
+        "service1",
+        "helpHidden",
+        "true",
+      );
+      expect(res.redirect).toHaveBeenCalledWith("/services/service1");
+    });
+
     it("calls updateServiceParam for all three params with 'true' when checkbox is checked", async () => {
       req.session.serviceConfigurationChanges["service1"] =
         hideServiceSession();

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -875,17 +875,17 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideApprover",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideSupport",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "helpHidden",
-        value: "true",
+        paramValue: "true",
       });
       expect(res.redirect).toHaveBeenCalledWith("/services/service1");
     });
@@ -900,17 +900,17 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideApprover",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideSupport",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "helpHidden",
-        value: "true",
+        paramValue: "true",
       });
     });
 
@@ -926,17 +926,17 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideApprover",
-        value: "false",
+        paramValue: "false",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideSupport",
-        value: "false",
+        paramValue: "false",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "helpHidden",
-        value: "false",
+        paramValue: "false",
       });
     });
 
@@ -964,17 +964,17 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideApprover",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideSupport",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "helpHidden",
-        value: "true",
+        paramValue: "true",
       });
       expect(updateService).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -997,17 +997,17 @@ describe("when confirming service config changes in the review page", () => {
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideApprover",
-        value: "false",
+        paramValue: "false",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "hideSupport",
-        value: "false",
+        paramValue: "false",
       });
       expect(updateServiceParam).toHaveBeenCalledWith({
         serviceId: "service1",
         paramName: "helpHidden",
-        value: "false",
+        paramValue: "false",
       });
       expect(updateService).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -979,7 +979,7 @@ describe("when confirming service config changes in the review page", () => {
       // isHiddenService on the service record must also be set for id-only services
       expect(updateService).toHaveBeenCalledWith({
         serviceId: "service1",
-        update: { isHiddenService: true },
+        update: { isHiddenService: 1 },
       });
     });
 
@@ -1011,7 +1011,7 @@ describe("when confirming service config changes in the review page", () => {
       // isHiddenService on the service record must also be cleared for id-only services
       expect(updateService).toHaveBeenCalledWith({
         serviceId: "service1",
-        update: { isHiddenService: false },
+        update: { isHiddenService: 0 },
       });
     });
 

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -618,7 +618,7 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).toHaveBeenCalledWith("service1", {
-          isHiddenService: false,
+          isHiddenService: 0,
         });
       });
 
@@ -640,7 +640,7 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).toHaveBeenCalledWith("service1", {
-          isHiddenService: false,
+          isHiddenService: 0,
         });
       });
 
@@ -662,7 +662,7 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).toHaveBeenCalledWith("service1", {
-          isHiddenService: false,
+          isHiddenService: 0,
         });
       });
 
@@ -684,7 +684,7 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).toHaveBeenCalledWith("service1", {
-          isHiddenService: false,
+          isHiddenService: 0,
         });
       });
 
@@ -707,7 +707,7 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).toHaveBeenCalledWith("service1", {
-          isHiddenService: true,
+          isHiddenService: 1,
         });
       });
 
@@ -797,6 +797,31 @@ describe("when getting the service config page", () => {
         await getServiceConfig(req, res);
 
         expect(updateService).not.toHaveBeenCalled();
+      });
+
+      it("should still render the page even if the auto-sync updateService call fails", async () => {
+        // The sync is best-effort: a failing API write must never cause a 500.
+        updateService.mockRejectedValue(new Error("API unavailable"));
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render.mock.calls[0][0]).toBe(
+          "services/views/serviceConfig",
+        );
       });
     });
   });

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -30,9 +30,14 @@ jest.mock("login.dfe.api-client/services", () => ({
   getServiceRaw: jest.fn(),
 }));
 
+jest.mock("../../../src/infrastructure/utils/services", () => ({
+  updateService: jest.fn(),
+}));
+
 const { getRequestMock, getResponseMock } = require("../../utils");
 const { getServiceConfig } = require("../../../src/app/services/serviceConfig");
 const { getServiceRaw } = require("login.dfe.api-client/services");
+const { updateService } = require("../../../src/infrastructure/utils/services");
 const { getUserServiceRoles } = require("../../../src/app/services/utils");
 const { ACTIONS } = require("../../../src/constants/serviceConfigConstants");
 
@@ -84,6 +89,8 @@ describe("when getting the service config page", () => {
     });
     getUserServiceRoles.mockReset();
     getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    updateService.mockReset();
+    updateService.mockResolvedValue();
     res.mockResetAll();
   });
 
@@ -303,5 +310,494 @@ describe("when getting the service config page", () => {
 
     expect(res.render.mock.calls).toHaveLength(1);
     expect(res.render.mock.calls[0][0]).toBe("services/views/serviceConfig");
+  });
+
+  describe("isServiceHidden flag — Hide Service checkbox state", () => {
+    const makeService = (overrides = {}) => ({
+      id: "service1",
+      name: "service one",
+      description: "service description",
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        token_endpoint_auth_method: "test",
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+        ...overrides.relyingParty,
+      },
+      ...overrides,
+    });
+
+    it("should set isServiceHidden=true for role-based service when params are boolean true", async () => {
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: "true",
+              hideSupport: "true",
+              helpHidden: "true",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(true);
+    });
+
+    it("should set isServiceHidden=true for role-based service when params are integer 1 (support console format)", async () => {
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: 1,
+              hideSupport: 1,
+              helpHidden: 1,
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(true);
+    });
+
+    it("should set isServiceHidden=false for role-based service when any param is false — scenario 7 (all false)", async () => {
+      // Scenario 7: all params false → unchecked
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "false",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for role-based service — scenario 8 (hideApprover=true, rest false)", async () => {
+      // Scenario 8: only hideApprover is true; not all three → unchecked
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: "true",
+              hideSupport: "false",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for role-based service — scenario 9 (hideSupport=true, rest false)", async () => {
+      // Scenario 9: only hideSupport is true → unchecked
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "true",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for role-based service — scenario 10 (helpHidden=true, rest false)", async () => {
+      // Scenario 10: only helpHidden is true → unchecked
+      getServiceRaw.mockReturnValue(
+        makeService({
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "false",
+              helpHidden: "true",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=true for id-only service when params are integer 1 (support console format) — scenario 0", async () => {
+      // Scenario 0: integer 1/0 from support console must be normalised to true/false.
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: 1,
+              hideSupport: 1,
+              helpHidden: 1,
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(true);
+    });
+
+    it("should set isServiceHidden=false for id-only service when all params are false regardless of isHiddenService value — scenarios 2-5", async () => {
+      // Checkbox is derived from params only. isHiddenService is kept in sync
+      // separately on save and must NOT override the checkbox display.
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "false",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for id-only service when only some params are true — scenario 3 (hideApprover=true, rest false)", async () => {
+      // All three params must be truthy; partial true is not enough.
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: "true",
+              hideSupport: "false",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for id-only service — scenario 4 (hideSupport=true, rest false)", async () => {
+      // Scenario 4: isHiddenService=1, hideApprover=false, hideSupport=true, helpHidden=false
+      // Not all three params are truthy so checkbox must be unchecked.
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "true",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=false for id-only service — scenario 5 (helpHidden=true, rest false)", async () => {
+      // Scenario 5: isHiddenService=1, hideApprover=false, hideSupport=false, helpHidden=true
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 1,
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "false",
+              helpHidden: "true",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    it("should set isServiceHidden=true for id-only service when all params are truthy regardless of isHiddenService value", async () => {
+      // Checkbox is derived from params; isHiddenService=false does not override
+      // truthy params.
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: false,
+          relyingParty: {
+            params: {
+              hideApprover: 1,
+              hideSupport: 1,
+              helpHidden: 1,
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(true);
+    });
+
+    it("should set isServiceHidden=false for id-only service when all params are false and isHiddenService=0", async () => {
+      getServiceRaw.mockReturnValue(
+        makeService({
+          isIdOnlyService: 1,
+          isHiddenService: 0,
+          relyingParty: {
+            params: {
+              hideApprover: "false",
+              hideSupport: "false",
+              helpHidden: "false",
+            },
+          },
+        }),
+      );
+
+      await getServiceConfig(req, res);
+
+      expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+    });
+
+    describe("auto-sync isHiddenService for id-only services — scenarios 2-5", () => {
+      it("should call updateService to clear isHiddenService when it is 1 but all params are false (scenario 2)", async () => {
+        // isHiddenService=1 with params=false is an inconsistent state that makes
+        // downstream apps (support console, help page) hide the service even
+        // though it should be visible. Auto-correct on page load.
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).toHaveBeenCalledWith("service1", {
+          isHiddenService: false,
+        });
+      });
+
+      it("should call updateService to clear isHiddenService when it is 1 and only some params are true (scenario 3)", async () => {
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "true",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).toHaveBeenCalledWith("service1", {
+          isHiddenService: false,
+        });
+      });
+
+      it("should call updateService to clear isHiddenService — scenario 4 (hideSupport=true, rest false)", async () => {
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "true",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).toHaveBeenCalledWith("service1", {
+          isHiddenService: false,
+        });
+      });
+
+      it("should call updateService to clear isHiddenService — scenario 5 (helpHidden=true, rest false)", async () => {
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "true",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).toHaveBeenCalledWith("service1", {
+          isHiddenService: false,
+        });
+      });
+
+      it("should call updateService to set isHiddenService when it is false but all params are truthy", async () => {
+        // Inverse inconsistency: params say hidden but isHiddenService=false.
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: false,
+            relyingParty: {
+              params: {
+                hideApprover: 1,
+                hideSupport: 1,
+                helpHidden: 1,
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).toHaveBeenCalledWith("service1", {
+          isHiddenService: true,
+        });
+      });
+
+      it("should NOT call updateService when isHiddenService is consistent with params (scenario 0 — all true)", async () => {
+        // isHiddenService=1 AND all params=1: no inconsistency, no sync needed.
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: 1,
+                hideSupport: 1,
+                helpHidden: 1,
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).not.toHaveBeenCalled();
+      });
+
+      it("should NOT call updateService when isHiddenService is consistent with params (all false)", async () => {
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 0,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).not.toHaveBeenCalled();
+      });
+
+      it("should NOT call updateService for role-based services regardless of param state", async () => {
+        // Role-based services do not have isHiddenService; no sync should occur.
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: false,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).not.toHaveBeenCalled();
+      });
+
+      it("should NOT call updateService during an amend-changes round-trip even if isHiddenService is inconsistent", async () => {
+        // During amend-changes (back from review page), auto-sync must not fire.
+        // The state may still be in-flight from a pending save operation.
+        req.query = { action: ACTIONS.AMEND_CHANGES };
+        req.session.serviceConfigurationChanges = {
+          [req.params.sid]: {},
+        };
+        getServiceRaw.mockReturnValue(
+          makeService({
+            isIdOnlyService: 1,
+            isHiddenService: 1,
+            relyingParty: {
+              params: {
+                hideApprover: "false",
+                hideSupport: "false",
+                helpHidden: "false",
+              },
+            },
+          }),
+        );
+
+        await getServiceConfig(req, res);
+
+        expect(updateService).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -889,3 +889,158 @@ describe("when editing the IMPLICIT flow service configuration", () => {
     ).toBe(undefined);
   });
 });
+
+describe("Hide Service checkbox — postServiceConfig session handling", () => {
+  let req;
+
+  const makeServiceRaw = (overrides = {}) => ({
+    id: "service1",
+    name: "service one",
+    description: "service description",
+    isIdOnlyService: false,
+    isHiddenService: 0,
+    relyingParty: {
+      client_id: "clientid",
+      client_secret: "dewier-thrombi-confounder-mikado",
+      service_home: "https://www.servicehome.com",
+      postResetUrl: "https://www.postreset.com",
+      redirect_uris: ["https://www.redirect.com"],
+      post_logout_redirect_uris: ["https://www.logout.com"],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      api_secret: "dewier-thrombi-confounder-mikado",
+      token_endpoint_auth_method: undefined,
+      params: {
+        hideApprover: "false",
+        hideSupport: "false",
+        helpHidden: "false",
+      },
+      ...overrides.relyingParty,
+    },
+    ...overrides,
+  });
+
+  const validBody = {
+    clientId: "clientid",
+    serviceHome: "https://www.servicehome.com",
+    postResetUrl: "https://www.postreset.com",
+    redirect_uris: ["https://www.redirect.com"],
+    post_logout_redirect_uris: ["https://www.logout.com"],
+    response_types: ["code"],
+    tokenEndpointAuthMethod: "client_secret_basic",
+  };
+
+  beforeEach(() => {
+    req = getRequestMock({
+      body: { ...validBody },
+      params: { sid: "service1" },
+      query: {},
+      session: { passport: { user: { sub: "user_id_uuid" } } },
+    });
+
+    getUserServiceRoles.mockReset();
+    getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    checkClientId.mockReset();
+    updateService.mockReset();
+    updateService.mockImplementation(() => Promise.resolve([]));
+    getServiceRaw.mockReset();
+    getServiceRaw.mockReturnValue(makeServiceRaw());
+    res.mockResetAll();
+  });
+
+  it("stores hideService in session when checkbox is ticked and DB value is false", async () => {
+    req.body.hideService = "yes";
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].hideService,
+    ).toEqual({
+      oldValue: false,
+      newValue: true,
+      isIdOnlyService: false,
+    });
+    expect(res.redirect).toHaveBeenCalledWith("review-service-configuration#");
+  });
+
+  it("stores hideService in session when checkbox is unticked and DB value is true", async () => {
+    getServiceRaw.mockReturnValue(
+      makeServiceRaw({
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      }),
+    );
+    req.body.hideService = undefined;
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].hideService,
+    ).toEqual({
+      oldValue: true,
+      newValue: false,
+      isIdOnlyService: false,
+    });
+  });
+
+  it("does not store hideService in session when checkbox state matches the DB", async () => {
+    req.body.hideService = undefined;
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].hideService,
+    ).toBeUndefined();
+  });
+
+  it("stores isIdOnlyService=true when hiding an id-only service", async () => {
+    getServiceRaw.mockReturnValue(makeServiceRaw({ isIdOnlyService: 1 }));
+    req.body.hideService = "yes";
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].hideService,
+    ).toEqual({
+      oldValue: false,
+      newValue: true,
+      isIdOnlyService: true,
+    });
+  });
+
+  it("preserves the submitted checkbox state (checked) when validation fails", async () => {
+    req.body.serviceHome = "not-a-valid-url";
+    req.body.hideService = "yes";
+
+    await postServiceConfig(req, res);
+
+    expect(res.render).toHaveBeenCalledTimes(1);
+    expect(res.render.mock.calls[0][1].isServiceHidden).toBe(true);
+  });
+
+  it("preserves the submitted checkbox state (unchecked) when validation fails", async () => {
+    getServiceRaw.mockReturnValue(
+      makeServiceRaw({
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      }),
+    );
+    req.body.serviceHome = "not-a-valid-url";
+    req.body.hideService = undefined;
+
+    await postServiceConfig(req, res);
+
+    expect(res.render).toHaveBeenCalledTimes(1);
+    expect(res.render.mock.calls[0][1].isServiceHidden).toBe(false);
+  });
+});


### PR DESCRIPTION
https://dfe-secureaccess.atlassian.net/browse/NSA-9688                                                                          

Adds a "Hide Service" checkbox to the service configuration edit page. When checked and saved, the intent is to hide the service from users, approvers, support, and the help page. When unchecked, the service becomes visible again.

The checkbox state is read from the service's existing database fields (`params.hideApprover`, `params.hideSupport`, `params.helpHidden`, and `isHiddenService` for id-only services) so it correctly reflects the current state when the page loads.

**Changes**

- serviceConfig.js: reads the current hidden state from the DB when building the service model, pre-checks the checkbox accordingly, tracks the checkbox change in the session separately from OIDC config fields, and preserves the checkbox state if the form fails validation and is re-rendered.

- confirmServiceConfig.js:  extracts the Hide Service change from the session and passes it to the review page separately from the standard OIDC changes table. Fixed a bug where `serviceHome` URL validation would incorrectly fire on the confirm page when only the Hide Service checkbox had changed. Stub code is in place (commented out with TODOs) to persist the changes via `updateServiceParam` and `updateService` once the related `login.dfe.api-client` task is complete.

- serviceConfig.ejs: adds the Hide Service checkbox to the form using GDS component styles, below the Post Reset URL field.

- confirmServiceConfig.ejs: adds a GDS warning block on the review page showing whether the service will be hidden or revealed. Fixes the Save button disabled state and the "no changes" empty state so both correctly account for a checkbox-only change.

**What is not yet implemented (blocked)**

The actual API calls to save the hidden state (`updateServiceParam` for `hideApprover`, `hideSupport`, `helpHidden`, and `updateService` for `isHiddenService` on id-only services) are stubbed out pending those methods being added to `login.dfe.api-client`. The TODOs are in confirmServiceConfig.js around the `postConfirmServiceConfig` function.

**Testing**
The `serviceConfig.test.js` and `confirmServiceConfig` test files cover the new checkbox handling logic.

**Related PR**
login.dfe.api-client: NSA-9688: Add updateServiceParam function

**Blocked dependency**
The backend endpoint is being created under NSA-9687.
The PUT /services/:service-id/params/:paramName endpoint does not exist yet in login.dfe.applications.
It is being built under NSA-9687: Add PUT endpoint to login.dfe.applications to modify serviceParams

