### PR TITLE
[NSA-9812] Fix policy role table overflow and remove flow for long/special-char names

### DIFF
--- a/src/app/services/getConfirmRemovePolicyRole.js
+++ b/src/app/services/getConfirmRemovePolicyRole.js
@@ -2,8 +2,18 @@ const { getServicePolicyRaw } = require("login.dfe.api-client/services");
 const logger = require("../../infrastructure/logger");
 
 const getConfirmRemovePolicyRole = async (req, res) => {
-  const name = req.query.name;
-  const code = req.query.code;
+  const roleId = req.query.roleId;
+
+  if (!roleId) {
+    logger.info("No roleId provided in query params", {
+      correlationId: req.id,
+    });
+    res.flash("error", "Role not found in policy.");
+    return res.redirect(
+      `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    );
+  }
+
   let policy;
 
   try {
@@ -22,10 +32,26 @@ const getConfirmRemovePolicyRole = async (req, res) => {
     );
   }
 
+  const role = (policy.roles ?? []).find((r) => r.id === roleId);
+
+  if (!role) {
+    logger.info(`[${roleId}] not found in existing policy`, {
+      correlationId: req.id,
+    });
+    res.flash(
+      "error",
+      "Role not found in policy. It may have already been removed.",
+    );
+    return res.redirect(
+      `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    );
+  }
+
   return res.render("services/views/confirmRemovePolicyRole", {
     csrfToken: req.csrfToken(),
-    name,
-    code,
+    name: role.name,
+    code: role.code,
+    roleId,
     policy,
     cancelLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
     backLink: `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,

--- a/src/app/services/postConfirmCreatePolicyRole.js
+++ b/src/app/services/postConfirmCreatePolicyRole.js
@@ -32,6 +32,11 @@ const addRoleToPolicy = async (
   );
 
   const newRole = await createServiceRole(model);
+  if (!newRole) {
+    throw new Error(
+      `createServiceRole returned no data for role [code: ${model.roleCode}]`,
+    );
+  }
   policy.roles.push(newRole);
   return newRole;
 };
@@ -95,9 +100,12 @@ const postConfirmCreatePolicyRole = async (req, res) => {
   }
 
   try {
-    allServiceRoles = await getServiceRolesRaw({
+    const serviceRolesResponse = await getServiceRolesRaw({
       serviceId: req.params.sid,
     });
+    allServiceRoles = Array.isArray(serviceRolesResponse)
+      ? serviceRolesResponse
+      : (serviceRolesResponse?.roles ?? []);
   } catch (error) {
     logger.error(
       `Error retrieving service roles for service ${req.params.sid}`,

--- a/src/app/services/postConfirmRemovePolicyRole.js
+++ b/src/app/services/postConfirmRemovePolicyRole.js
@@ -1,6 +1,6 @@
 const {
   getServicePolicyRaw,
-  getServicePoliciesRaw,
+  getPaginatedServicePoliciesRaw,
   updateServicePolicyRaw,
   deleteServiceRoleRaw,
 } = require("login.dfe.api-client/services");
@@ -65,19 +65,16 @@ const postConfirmRemovePolicyRole = async (req, res) => {
   /* Check if the role exists in other policies for this service.
   If it does, remove the role and update the policy.
   If not, remove the role and delete the role completely. */
-  let allServicePolicies;
   let allRoleOccurrences;
 
   try {
-    allServicePolicies = await getServicePoliciesRaw({
+    const policiesResponse = await getPaginatedServicePoliciesRaw({
       serviceId: req.params.sid,
+      page: 1,
+      pageSize: 500,
     });
 
-    const servicePolicies = Array.isArray(allServicePolicies)
-      ? allServicePolicies
-      : (allServicePolicies?.policies ?? []);
-
-    allRoleOccurrences = servicePolicies
+    allRoleOccurrences = (policiesResponse?.policies ?? [])
       .flatMap((servicePolicy) => servicePolicy.roles ?? [])
       .filter((role) => role.id === roleInPolicy.id);
   } catch (error) {

--- a/src/app/services/postConfirmRemovePolicyRole.js
+++ b/src/app/services/postConfirmRemovePolicyRole.js
@@ -18,12 +18,18 @@ const handleApiError = (error, req, res, errorMessage, flashMessage) => {
 };
 
 const postConfirmRemovePolicyRole = async (req, res) => {
-  const model = {
-    appId: req.params.sid,
-    roleName: req.body.name || "",
-    roleCode: req.body.code || "",
-    validationMessages: {},
-  };
+  const roleId = req.body.roleId;
+
+  if (!roleId) {
+    logger.info("No roleId provided in request body", {
+      correlationId: req.id,
+    });
+    res.flash("error", "Role not found in policy.");
+    return res.redirect(
+      `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    );
+  }
+
   let policy;
 
   try {
@@ -41,35 +47,38 @@ const postConfirmRemovePolicyRole = async (req, res) => {
     );
   }
 
-  const roleInPolicy = policy.roles.find(
-    (role) => role.name === model.roleName && role.code === model.roleCode,
-  );
+  const roleInPolicy = (policy.roles ?? []).find((role) => role.id === roleId);
 
   if (!roleInPolicy) {
-    logger.info(
-      `[${model.roleName}] [${model.roleCode}] not found in existing policy`,
-      { correlationId: req.id },
-    );
+    logger.info(`[${roleId}] not found in existing policy`, {
+      correlationId: req.id,
+    });
     res.flash(
-      "info",
-      `Policy role [${model.roleName}] [${model.roleCode}] not found in policy. Policy has not been modified`,
+      "error",
+      "Role not found in policy. It may have already been removed.",
     );
-    return res.redirect("conditionsAndRoles");
+    return res.redirect(
+      `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+    );
   }
 
   /* Check if the role exists in other policies for this service.
   If it does, remove the role and update the policy.
   If not, remove the role and delete the role completely. */
   let allServicePolicies;
-  let roleInMultiplePolicies;
+  let allRoleOccurrences;
 
   try {
     allServicePolicies = await getServicePoliciesRaw({
       serviceId: req.params.sid,
     });
 
-    roleInMultiplePolicies = allServicePolicies
-      .flatMap((serviceRole) => serviceRole.roles)
+    const servicePolicies = Array.isArray(allServicePolicies)
+      ? allServicePolicies
+      : (allServicePolicies?.policies ?? []);
+
+    allRoleOccurrences = servicePolicies
+      .flatMap((servicePolicy) => servicePolicy.roles ?? [])
       .filter((role) => role.id === roleInPolicy.id);
   } catch (error) {
     return handleApiError(
@@ -81,8 +90,7 @@ const postConfirmRemovePolicyRole = async (req, res) => {
     );
   }
 
-  const roleIndex = policy.roles.indexOf(roleInPolicy);
-  policy.roles.splice(roleIndex, 1);
+  policy.roles = policy.roles.filter((role) => role !== roleInPolicy);
 
   try {
     await updateServicePolicyRaw({
@@ -100,7 +108,7 @@ const postConfirmRemovePolicyRole = async (req, res) => {
     );
   }
 
-  const roleUsedInOtherPolicies = roleInMultiplePolicies.length > 1;
+  const roleUsedInOtherPolicies = allRoleOccurrences.length > 1;
 
   if (!roleUsedInOtherPolicies) {
     logger.info(
@@ -127,7 +135,7 @@ const postConfirmRemovePolicyRole = async (req, res) => {
   }
 
   logger.audit(
-    `${req.user.email} removed a policy role with name '${model.roleName}'`,
+    `${req.user.email} removed a policy role with name '${roleInPolicy.name}'`,
     {
       type: "manage",
       subType: "policy-role-removed",
@@ -135,14 +143,14 @@ const postConfirmRemovePolicyRole = async (req, res) => {
       userEmail: req.user.email,
       serviceId: req.params.sid,
       policyId: req.params.pid,
-      name: model.roleName,
-      code: model.roleCode,
+      name: roleInPolicy.name,
+      code: roleInPolicy.code,
     },
   );
 
   res.flash(
     "info",
-    `Policy role ${model.roleName} ${model.roleCode} successfully removed`,
+    `Policy role ${roleInPolicy.name} ${roleInPolicy.code} successfully removed`,
   );
 
   return res.redirect("conditionsAndRoles");

--- a/src/app/services/views/confirmRemovePolicyRole.ejs
+++ b/src/app/services/views/confirmRemovePolicyRole.ejs
@@ -28,8 +28,7 @@
 
             <form method="post">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>"/>
-                <input type="hidden" name="name" value="<%= locals.name %>"/>
-                <input type="hidden" name="code" value="<%= locals.code %>"/>
+                <input type="hidden" name="roleId" value="<%= locals.roleId %>"/>
 
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">Yes, remove this role</button>

--- a/src/app/services/views/policyConditionsAndRoles.ejs
+++ b/src/app/services/views/policyConditionsAndRoles.ejs
@@ -135,24 +135,24 @@
                 </div>
                 <div class="govuk-tabs__panel" id="policy-roles-panel">
                     <h2 class="govuk-heading-m govuk-visually-hidden">Policy Roles</h2>
-                    <table class="govuk-table">
+                    <table class="govuk-table" style="table-layout: fixed; width: 100%;">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row sortable">
-                                <th scope="col" class="govuk-table__header width-40">Name</th>
-                                <th scope="col" class="govuk-table__header width-20">Code</th>
-                                <th scope="col" class="govuk-table__header width-20">ID</th>
+                                <th scope="col" class="govuk-table__header" style="width: 40%;">Name</th>
+                                <th scope="col" class="govuk-table__header" style="width: 20%;">Code</th>
+                                <th scope="col" class="govuk-table__header" style="width: 20%;">ID</th>
                                 <%  if (locals.canUserModifyPolicyConditionsAndRoles) { %>
-                                    <th scope="col" class="govuk-table__header width-10 govuk-table__header--numeric">Status</th>
-                                    <th scope="col" class="govuk-table__header width-10"></th>
+                                    <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 10%;">Status</th>
+                                    <th scope="col" class="govuk-table__header" style="width: 10%;"><span class="govuk-visually-hidden">Actions</span></th>
                                 <% } else {%>
-                                    <th scope="col" class="govuk-table__header width-20 govuk-table__header--numeric">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 20%;">Status</th>
                                 <% }%>
                             </tr>
                         </thead>
                         <tbody class="govuk-table__body">
                         <% if (locals.policy.roles.length === 0) { %>
                             <tr class="govuk-table__row">
-                                <td class="govuk-table__cell" colspan="4">
+                                <td class="govuk-table__cell" colspan="<%= locals.canUserModifyPolicyConditionsAndRoles ? 5 : 4 %>">
                                     <div class="empty-state">
                                         <p class="govuk-body"><%= locals.policy.name %> has no roles</p>
                                     </div>
@@ -162,12 +162,16 @@
                         <% for (let i = 0; i < locals.policy.roles.length; i++) { %>
                             <% const role = locals.policy.roles[i];%>
                             <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><%= role.name %></td>
-                                <td class="govuk-table__cell"><%= role.code %></td>
-                                <td class="govuk-table__cell"><%= role.numericId %></td>
+                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.name %></td>
+                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.code %></td>
+                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.numericId %></td>
                                 <td class="govuk-table__cell govuk-table__cell--numeric"><%= role.status ? role.status.id : '' %></td>
                                 <%  if (locals.canUserModifyPolicyConditionsAndRoles) { %>
-                                    <td class="govuk-table__cell"><a href="confirm-remove-policy-role?name=<%=role.name%>&code=<%=role.code%>">Remove</a></td>
+                                    <td class="govuk-table__cell">
+                                        <a href="confirm-remove-policy-role?roleId=<%=role.id%>">
+                                            Remove<span class="govuk-visually-hidden"> role <%= role.name %> (code <%= role.code %>, ID <%= role.numericId %>)</span>
+                                        </a>
+                                    </td>
                                 <% } %>
                             </tr>
                         <% } %>

--- a/test/app/services/getConfirmRemovePolicyRole.test.js
+++ b/test/app/services/getConfirmRemovePolicyRole.test.js
@@ -48,8 +48,7 @@ describe("when calling the getConfirmRemovePolicyRole function", () => {
         pid: "policy-id",
       },
       query: {
-        name: "School",
-        code: "CheckRecord_School",
+        roleId: "717E2ECB-8B76-402C-A142-15DD486CBE95",
       },
     };
 
@@ -80,6 +79,7 @@ describe("when calling the getConfirmRemovePolicyRole function", () => {
       csrfToken: "token",
       name: "School",
       code: "CheckRecord_School",
+      roleId: "717E2ECB-8B76-402C-A142-15DD486CBE95",
       policy: policy,
       cancelLink: "/services/service-id/policies/policy-id/conditionsAndRoles",
       backLink: "/services/service-id/policies/policy-id/conditionsAndRoles",
@@ -95,6 +95,45 @@ describe("when calling the getConfirmRemovePolicyRole function", () => {
       serviceId: "service-id",
       policyId: "policy-id",
     });
+  });
+
+  it("should redirect with error when role ID is not found in policy", async () => {
+    req.query.roleId = "NON-EXISTENT-ROLE-ID";
+
+    await getConfirmRemovePolicyRole(req, res);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[NON-EXISTENT-ROLE-ID] not found in existing policy",
+      { correlationId: "correlationId" },
+    );
+    expect(res.flash).toHaveBeenCalledWith(
+      "error",
+      "Role not found in policy. It may have already been removed.",
+    );
+    expect(res.redirect).toHaveBeenCalledWith(
+      "/services/service-id/policies/policy-id/conditionsAndRoles",
+    );
+    expect(res.render).not.toHaveBeenCalled();
+  });
+
+  it("should redirect with error when roleId query param is missing", async () => {
+    delete req.query.roleId;
+
+    await getConfirmRemovePolicyRole(req, res);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "No roleId provided in query params",
+      { correlationId: "correlationId" },
+    );
+    expect(res.flash).toHaveBeenCalledWith(
+      "error",
+      "Role not found in policy.",
+    );
+    expect(res.redirect).toHaveBeenCalledWith(
+      "/services/service-id/policies/policy-id/conditionsAndRoles",
+    );
+    expect(res.render).not.toHaveBeenCalled();
+    expect(getServicePolicyRaw).not.toHaveBeenCalled();
   });
 
   it("should handle errors when getServicePolicyRaw fails", async () => {
@@ -119,17 +158,5 @@ describe("when calling the getConfirmRemovePolicyRole function", () => {
     expect(res.redirect).toHaveBeenCalledWith(
       "/services/service-id/policies/policy-id/conditionsAndRoles",
     );
-  });
-
-  it("should pass role name and code from query parameters", async () => {
-    req.query.name = "Test Role";
-    req.query.code = "test_role_code";
-
-    await getConfirmRemovePolicyRole(req, res);
-
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      name: "Test Role",
-      code: "test_role_code",
-    });
   });
 });

--- a/test/app/services/postConfirmCreatePolicyRole.test.js
+++ b/test/app/services/postConfirmCreatePolicyRole.test.js
@@ -222,6 +222,32 @@ describe("when using the postConfirmCreatePolicyRole function", () => {
     );
   });
 
+  it("should handle a paged response from getServiceRolesRaw", async () => {
+    req.session.createPolicyRoleData.roleName = "Existing Role";
+    req.session.createPolicyRoleData.roleCode = "existing_role";
+
+    getServiceRolesRaw.mockResolvedValue({
+      roles: [
+        {
+          id: "A1B2C3D4-5E6F-7G8H-9I0J-K1L2M3N4O5P6",
+          name: "Existing Role",
+          code: "existing_role",
+          numericId: "12345",
+          status: ["1"],
+        },
+      ],
+    });
+
+    await postConfirmCreatePolicyRole(req, res);
+
+    expect(createServiceRole).not.toHaveBeenCalled();
+    expect(updateServicePolicyRaw).toHaveBeenCalled();
+    expect(res.flash).toHaveBeenCalledWith(
+      "info",
+      "Policy role Existing Role existing_role successfully added",
+    );
+  });
+
   it("should show a different flash message when the added role name differs from the model name", async () => {
     req.session.createPolicyRoleData.roleName = "Different Name";
     req.session.createPolicyRoleData.roleCode = "existing_role";
@@ -262,6 +288,19 @@ describe("when using the postConfirmCreatePolicyRole function", () => {
     expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
     expect(req.session.createPolicyRoleData).toBeDefined();
     expect(req.session.createPolicyRoleData.roleName).toBe("New Test Role");
+  });
+
+  it("should handle createServiceRole returning undefined (e.g. empty API response body)", async () => {
+    createServiceRole.mockResolvedValue(undefined);
+    req.session.save = jest.fn((callback) => callback());
+
+    await postConfirmCreatePolicyRole(req, res);
+
+    expect(res.flash).toHaveBeenCalledWith(
+      "error",
+      "Failed to update policy. Please try again.",
+    );
+    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
   });
 
   it("should handle errors when getServicePolicyRaw fails", async () => {

--- a/test/app/services/postConfirmRemovePolicyRole.test.js
+++ b/test/app/services/postConfirmRemovePolicyRole.test.js
@@ -49,7 +49,7 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
           status: ["1"],
         },
         {
-          id: "A1B2C3D4-5E6F-7G8H-9I0J-K1L2M3N4O5P6",
+          id: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
           name: "Teacher",
           code: "CheckRecord_Teacher",
           numericId: "22998",
@@ -89,8 +89,7 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
         pid: "policy-id",
       },
       body: {
-        name: "School",
-        code: "CheckRecord_School",
+        roleId: "717E2ECB-8B76-402C-A142-15DD486CBE95",
       },
     });
 
@@ -122,7 +121,7 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       policy: expect.objectContaining({
         roles: [
           {
-            id: "A1B2C3D4-5E6F-7G8H-9I0J-K1L2M3N4O5P6",
+            id: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
             name: "Teacher",
             code: "CheckRecord_Teacher",
             numericId: "22998",
@@ -167,7 +166,7 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       policy: expect.objectContaining({
         roles: [
           {
-            id: "A1B2C3D4-5E6F-7G8H-9I0J-K1L2M3N4O5P6",
+            id: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
             name: "Teacher",
             code: "CheckRecord_Teacher",
             numericId: "22998",
@@ -195,26 +194,183 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
     expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
   });
 
-  it("should flash an info message when the role does not exist in the policy", async () => {
-    req.body.name = "NonExistent";
-    req.body.code = "non_existent_code";
+  it("should handle a paged response from getServicePoliciesRaw", async () => {
+    getServicePoliciesRaw.mockResolvedValue({
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+        {
+          id: "ANOTHER-POLICY-ID",
+          name: "Policy 2",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+      ],
+    });
+
+    await postConfirmRemovePolicyRole(req, res);
+
+    expect(deleteServiceRoleRaw).not.toHaveBeenCalled();
+
+    expect(res.flash).toHaveBeenCalledWith(
+      "info",
+      "Policy role School CheckRecord_School successfully removed",
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
+  });
+
+  it("should flash an error when the role ID does not match any role in the policy", async () => {
+    req.body.roleId = "NON-EXISTENT-ROLE-ID";
 
     await postConfirmRemovePolicyRole(req, res);
 
     expect(logger.info).toHaveBeenCalledWith(
-      "[NonExistent] [non_existent_code] not found in existing policy",
+      "[NON-EXISTENT-ROLE-ID] not found in existing policy",
       { correlationId: "correlationId" },
     );
 
     expect(res.flash).toHaveBeenCalledWith(
-      "info",
-      "Policy role [NonExistent] [non_existent_code] not found in policy. Policy has not been modified",
+      "error",
+      "Role not found in policy. It may have already been removed.",
     );
 
-    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
+    expect(res.redirect).toHaveBeenCalledWith(
+      "/services/service-id/policies/policy-id/conditionsAndRoles",
+    );
 
     expect(updateServicePolicyRaw).not.toHaveBeenCalled();
     expect(deleteServiceRoleRaw).not.toHaveBeenCalled();
+  });
+
+  it("should successfully remove a role with special characters in its name", async () => {
+    const specialCharsRoleId = "C3A2B1D0-E4F5-6789-ABCD-123456789ABC";
+    const specialCharsName =
+      "Q0_KLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_'{|}~abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const specialCharsCode = "role_code_250_special_chars";
+
+    getServicePolicyRaw.mockResolvedValue({
+      id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+      name: "Test Service - Test Policy",
+      applicationId: "32A923EE-B729-44B1-BB52-1789FD08862A",
+      status: { id: 1 },
+      conditions: [],
+      roles: [
+        {
+          id: specialCharsRoleId,
+          name: specialCharsName,
+          code: specialCharsCode,
+          numericId: "23058",
+          status: ["1"],
+        },
+      ],
+    });
+
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+        name: "Policy 1",
+        roles: [
+          {
+            id: specialCharsRoleId,
+            name: specialCharsName,
+            code: specialCharsCode,
+          },
+        ],
+      },
+    ]);
+
+    req.body.roleId = specialCharsRoleId;
+
+    await postConfirmRemovePolicyRole(req, res);
+
+    expect(updateServicePolicyRaw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ roles: [] }),
+      }),
+    );
+
+    expect(deleteServiceRoleRaw).toHaveBeenCalledWith({
+      roleId: specialCharsRoleId,
+      serviceId: "32A923EE-B729-44B1-BB52-1789FD08862A",
+    });
+
+    expect(res.flash).toHaveBeenCalledWith(
+      "info",
+      `Policy role ${specialCharsName} ${specialCharsCode} successfully removed`,
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
+  });
+
+  it("should successfully remove a role with a 250-character name", async () => {
+    const longNameRoleId = "F1E2D3C4-B5A6-7890-CDEF-1234567890AB";
+    const longName =
+      "Leadspaces Role Management Access Control Security Application Platform Integration Governance Operations Administration Compliance Configuration Monitoring Leadership Strategy Planning Execution Support Responsibility Enterprise Role ManagementAAAAA";
+    const longNameCode = "role_code_250_char_name";
+
+    expect(longName.length).toBe(250);
+
+    getServicePolicyRaw.mockResolvedValue({
+      id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+      name: "Test Service - Test Policy",
+      applicationId: "32A923EE-B729-44B1-BB52-1789FD08862A",
+      status: { id: 1 },
+      conditions: [],
+      roles: [
+        {
+          id: longNameRoleId,
+          name: longName,
+          code: longNameCode,
+          numericId: "23059",
+          status: ["1"],
+        },
+      ],
+    });
+
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+        name: "Policy 1",
+        roles: [{ id: longNameRoleId, name: longName, code: longNameCode }],
+      },
+    ]);
+
+    req.body.roleId = longNameRoleId;
+
+    await postConfirmRemovePolicyRole(req, res);
+
+    expect(updateServicePolicyRaw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ roles: [] }),
+      }),
+    );
+
+    expect(deleteServiceRoleRaw).toHaveBeenCalledWith({
+      roleId: longNameRoleId,
+      serviceId: "32A923EE-B729-44B1-BB52-1789FD08862A",
+    });
+
+    expect(res.flash).toHaveBeenCalledWith(
+      "info",
+      `Policy role ${longName} ${longNameCode} successfully removed`,
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
   });
 
   it("should log an audit entry after successfully removing a role", async () => {
@@ -347,16 +503,24 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
     );
   });
 
-  it("should handle missing body parameters", async () => {
+  it("should flash an error when roleId is missing from request body", async () => {
     req.body = {};
 
     await postConfirmRemovePolicyRole(req, res);
 
-    expect(res.flash).toHaveBeenCalledWith(
-      "info",
-      "Policy role [] [] not found in policy. Policy has not been modified",
+    expect(logger.info).toHaveBeenCalledWith(
+      "No roleId provided in request body",
+      { correlationId: "correlationId" },
     );
 
-    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
+    expect(res.flash).toHaveBeenCalledWith(
+      "error",
+      "Role not found in policy.",
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      "/services/service-id/policies/policy-id/conditionsAndRoles",
+    );
+    expect(getServicePolicyRaw).not.toHaveBeenCalled();
   });
 });

--- a/test/app/services/postConfirmRemovePolicyRole.test.js
+++ b/test/app/services/postConfirmRemovePolicyRole.test.js
@@ -11,7 +11,7 @@ const { getRequestMock, getResponseMock } = require("../../utils");
 const postConfirmRemovePolicyRole = require("../../../src/app/services/postConfirmRemovePolicyRole");
 const {
   getServicePolicyRaw,
-  getServicePoliciesRaw,
+  getPaginatedServicePoliciesRaw,
   updateServicePolicyRaw,
   deleteServiceRoleRaw,
 } = require("login.dfe.api-client/services");
@@ -58,30 +58,32 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       ],
     };
 
-    const allServicePolicies = [
-      {
-        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-        name: "Policy 1",
-        roles: [
-          {
-            id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-            name: "School",
-            code: "CheckRecord_School",
-          },
-        ],
-      },
-      {
-        id: "ANOTHER-POLICY-ID",
-        name: "Policy 2",
-        roles: [
-          {
-            id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-            name: "School",
-            code: "CheckRecord_School",
-          },
-        ],
-      },
-    ];
+    const allServicePolicies = {
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+        {
+          id: "ANOTHER-POLICY-ID",
+          name: "Policy 2",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+      ],
+    };
 
     req = getRequestMock({
       params: {
@@ -96,8 +98,8 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
     getServicePolicyRaw.mockReset();
     getServicePolicyRaw.mockResolvedValue(policy);
 
-    getServicePoliciesRaw.mockReset();
-    getServicePoliciesRaw.mockResolvedValue(allServicePolicies);
+    getPaginatedServicePoliciesRaw.mockReset();
+    getPaginatedServicePoliciesRaw.mockResolvedValue(allServicePolicies);
 
     updateServicePolicyRaw.mockReset();
     updateServicePolicyRaw.mockResolvedValue(undefined);
@@ -142,21 +144,21 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
   });
 
   it("should remove a role from the policy and delete it when it does not exist in other policies", async () => {
-    const policiesWithSingleRole = [
-      {
-        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-        name: "Policy 1",
-        roles: [
-          {
-            id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-            name: "School",
-            code: "CheckRecord_School",
-          },
-        ],
-      },
-    ];
-
-    getServicePoliciesRaw.mockResolvedValue(policiesWithSingleRole);
+    getPaginatedServicePoliciesRaw.mockResolvedValue({
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+      ],
+    });
 
     await postConfirmRemovePolicyRole(req, res);
 
@@ -185,46 +187,6 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       "[32A923EE-B729-44B1-BB52-1789FD08862A] [717E2ECB-8B76-402C-A142-15DD486CBE95] does not exist in any other policies for this service. Calling deleteServiceRoleRaw.",
       { correlationId: "correlationId" },
     );
-
-    expect(res.flash).toHaveBeenCalledWith(
-      "info",
-      "Policy role School CheckRecord_School successfully removed",
-    );
-
-    expect(res.redirect).toHaveBeenCalledWith("conditionsAndRoles");
-  });
-
-  it("should handle a paged response from getServicePoliciesRaw", async () => {
-    getServicePoliciesRaw.mockResolvedValue({
-      policies: [
-        {
-          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-          name: "Policy 1",
-          roles: [
-            {
-              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-              name: "School",
-              code: "CheckRecord_School",
-            },
-          ],
-        },
-        {
-          id: "ANOTHER-POLICY-ID",
-          name: "Policy 2",
-          roles: [
-            {
-              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-              name: "School",
-              code: "CheckRecord_School",
-            },
-          ],
-        },
-      ],
-    });
-
-    await postConfirmRemovePolicyRole(req, res);
-
-    expect(deleteServiceRoleRaw).not.toHaveBeenCalled();
 
     expect(res.flash).toHaveBeenCalledWith(
       "info",
@@ -280,19 +242,21 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       ],
     });
 
-    getServicePoliciesRaw.mockResolvedValue([
-      {
-        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-        name: "Policy 1",
-        roles: [
-          {
-            id: specialCharsRoleId,
-            name: specialCharsName,
-            code: specialCharsCode,
-          },
-        ],
-      },
-    ]);
+    getPaginatedServicePoliciesRaw.mockResolvedValue({
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [
+            {
+              id: specialCharsRoleId,
+              name: specialCharsName,
+              code: specialCharsCode,
+            },
+          ],
+        },
+      ],
+    });
 
     req.body.roleId = specialCharsRoleId;
 
@@ -342,13 +306,15 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
       ],
     });
 
-    getServicePoliciesRaw.mockResolvedValue([
-      {
-        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-        name: "Policy 1",
-        roles: [{ id: longNameRoleId, name: longName, code: longNameCode }],
-      },
-    ]);
+    getPaginatedServicePoliciesRaw.mockResolvedValue({
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [{ id: longNameRoleId, name: longName, code: longNameCode }],
+        },
+      ],
+    });
 
     req.body.roleId = longNameRoleId;
 
@@ -415,9 +381,9 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
     );
   });
 
-  it("should handle errors when getServicePoliciesRaw fails", async () => {
+  it("should handle errors when getPaginatedServicePoliciesRaw fails", async () => {
     const mockError = new Error("Policies Fetch Error");
-    getServicePoliciesRaw.mockRejectedValue(mockError);
+    getPaginatedServicePoliciesRaw.mockRejectedValue(mockError);
 
     await postConfirmRemovePolicyRole(req, res);
 
@@ -464,21 +430,21 @@ describe("when using the postConfirmRemovePolicyRole function", () => {
   });
 
   it("should handle errors when deleteServiceRoleRaw fails", async () => {
-    const policiesWithSingleRole = [
-      {
-        id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
-        name: "Policy 1",
-        roles: [
-          {
-            id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
-            name: "School",
-            code: "CheckRecord_School",
-          },
-        ],
-      },
-    ];
-
-    getServicePoliciesRaw.mockResolvedValue(policiesWithSingleRole);
+    getPaginatedServicePoliciesRaw.mockResolvedValue({
+      policies: [
+        {
+          id: "6C8172B6-011B-4526-B04D-E2809A3D71A2",
+          name: "Policy 1",
+          roles: [
+            {
+              id: "717E2ECB-8B76-402C-A142-15DD486CBE95",
+              name: "School",
+              code: "CheckRecord_School",
+            },
+          ],
+        },
+      ],
+    });
 
     const mockError = new Error("Delete Error");
     deleteServiceRoleRaw.mockRejectedValue(mockError);


### PR DESCRIPTION
## Summary

[NSA-9812](https://dfe-secureaccess.atlassian.net/browse/NSA-9812)

After NSA-9313 increased the role name limit to 250 characters, two bugs were introduced in the policy roles UI. The Remove button stopped working for roles with special characters or long names because name/code were passed as URL query parameters, causing encoding mismatches. Fixed by switching to UUID (`roleId`) throughout the GET → confirm → POST flow. The roles table layout also broke for long names, causing text to overflow columns. Fixed by applying `table-layout: fixed` with percentage widths and `overflow-wrap: break-word` on all text cells.

Paged API responses from `getServicePoliciesRaw` and `getServiceRolesRaw` were crashing remove and create flows as the code only handled the array case - fixed with an `Array.isArray` check. Role creation was also silently failing in dev for names over 125 chars; fixed by throwing explicitly when `createServiceRole` returns no data so the error is caught, logged, and shown to the user.

## Changes

- `policyConditionsAndRoles.ejs` - Remove link passes `?roleId=<uuid>`; `table-layout: fixed` with `overflow-wrap: break-word`; dynamic empty-state colspan; action column header visually hidden
- `getConfirmRemovePolicyRole.js` - reads `roleId` from query, resolves name/code server-side; guards for missing roleId and role not found both redirect with absolute paths
- `postConfirmRemovePolicyRole.js` - reads `roleId` from body, finds role by UUID; paged response normalisation for `getServicePoliciesRaw`; role removal uses `filter` instead of `splice`


## Testing

- [x] Remove a policy role whose name contains special characters - confirm it removes successfully
- [x] Remove a policy role with a 250-character name - confirm it removes successfully
- [x] Create a policy role with a 250-character name containing special characters - confirm it creates successfully
- [x] Verify the roles table does not overflow for long role names
- [x] Verify audit log entry is recorded on successful removal
- [x] All unit tests pass

Related PR - https://github.com/DFE-Digital/login.dfe.access/pull/153
