### PR TITLE
Feature/nsa 9688 hide service

### DIFF
--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -1,7 +1,10 @@
 const niceware = require("niceware");
 const UrlValidator = require("login.dfe.validation/src/urlValidator");
 const { updateService } = require("../../infrastructure/utils/services");
-const { getServiceRaw } = require("login.dfe.api-client/services");
+const {
+  getServiceRaw,
+  updateServiceParam,
+} = require("login.dfe.api-client/services");
 const logger = require("../../infrastructure/logger");
 const {
   getUserServiceRoles,
@@ -93,6 +96,7 @@ const buildCurrentServiceModel = async (req) => {
   });
   return {
     name: service.name || "",
+    isIdOnlyService: !!service.isIdOnlyService,
   };
 };
 
@@ -502,6 +506,8 @@ const postConfirmServiceConfig = async (req, res) => {
     const serviceConfigChanges = {
       ...req.session.serviceConfigurationChanges[req.params.sid],
     };
+    const hideChange = serviceConfigChanges.isServiceHidden;
+    delete serviceConfigChanges.isServiceHidden;
     delete serviceConfigChanges.authFlowType;
 
     const editedFields = Object.entries(serviceConfigChanges)
@@ -550,6 +556,32 @@ const postConfirmServiceConfig = async (req, res) => {
     };
 
     await updateService(req.params.sid, updatedService);
+
+    if (hideChange?.newValue !== undefined) {
+      const shouldHide = hideChange.newValue === "Hidden";
+      await Promise.all([
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "hideApprover",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "hideSupport",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "helpHidden",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+      ]);
+      if (currentService.isIdOnlyService) {
+        await updateService(req.params.sid, {
+          isHiddenService: shouldHide ? 1 : 0,
+        });
+      }
+    }
 
     logger.audit(`${req.user.email} updated service configuration`, {
       type: "manage",

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -158,6 +158,24 @@ const getServiceConfig = async (req, res) => {
     }
     const manageRolesForService = await getUserServiceRoles(req);
     const serviceModel = await buildCurrentServiceModel(req);
+    if (
+      req.query?.action !== ACTIONS.AMEND_CHANGES &&
+      serviceModel.rawService.isIdOnlyService
+    ) {
+      const paramsTruthy =
+        isTruthyParam(
+          serviceModel.rawService.relyingParty?.params?.hideApprover,
+        ) &&
+        isTruthyParam(
+          serviceModel.rawService.relyingParty?.params?.hideSupport,
+        ) &&
+        isTruthyParam(serviceModel.rawService.relyingParty?.params?.helpHidden);
+      if (
+        paramsTruthy !== isTruthyParam(serviceModel.rawService.isHiddenService)
+      ) {
+        await updateService(sid, { isHiddenService: paramsTruthy ? 1 : 0 });
+      }
+    }
     return res.render("services/views/serviceConfig", {
       csrfToken: req.csrfToken(),
       service: {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -174,6 +174,7 @@ const getServiceConfig = async (req, res) => {
         paramsTruthy !== isTruthyParam(serviceModel.rawService.isHiddenService)
       ) {
         await updateService(sid, { isHiddenService: paramsTruthy ? 1 : 0 });
+        serviceModel.isServiceHidden = paramsTruthy;
       }
     }
     return res.render("services/views/serviceConfig", {

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -595,10 +595,12 @@ const postServiceConfig = async (req, res) => {
 
     const currentService = serviceModels.currentServiceModel;
     const oldService = serviceModels.oldServiceConfigModel;
+    const { isServiceHidden: oldIsServiceHidden } = serviceModels;
     const model = await validate(req, currentService, oldService);
 
     if (Object.keys(model.validationMessages).length > 0) {
       model.csrfToken = req.csrfToken();
+      model.service.isServiceHidden = oldIsServiceHidden;
       return res.render("services/views/serviceConfig", model);
     }
 
@@ -653,31 +655,38 @@ const postServiceConfig = async (req, res) => {
 
       req.session.serviceConfigurationChanges[sid].authFlowType =
         model.authFlowType;
-
-      if (
-        req.session.serviceConfigurationChanges[sid].postLogoutRedirectUris ===
-        undefined
-      ) {
-        req.session.serviceConfigurationChanges[sid].postLogoutRedirectUris =
-          {};
-        req.session.serviceConfigurationChanges[
-          sid
-        ].postLogoutRedirectUris.oldValue =
-          model.service.postLogoutRedirectUris;
-        req.session.serviceConfigurationChanges[
-          sid
-        ].postLogoutRedirectUris.newValue = undefined;
-      }
-      if (
-        req.session.serviceConfigurationChanges[sid].redirectUris === undefined
-      ) {
-        req.session.serviceConfigurationChanges[sid].redirectUris = {};
-        req.session.serviceConfigurationChanges[sid].redirectUris.oldValue =
-          model.service.redirectUris;
-        req.session.serviceConfigurationChanges[sid].redirectUris.newValue =
-          undefined;
-      }
     }
+
+    if (
+      req.session.serviceConfigurationChanges[sid].postLogoutRedirectUris ===
+      undefined
+    ) {
+      req.session.serviceConfigurationChanges[sid].postLogoutRedirectUris = {};
+      req.session.serviceConfigurationChanges[
+        sid
+      ].postLogoutRedirectUris.oldValue = model.service.postLogoutRedirectUris;
+      req.session.serviceConfigurationChanges[
+        sid
+      ].postLogoutRedirectUris.newValue = undefined;
+    }
+    if (
+      req.session.serviceConfigurationChanges[sid].redirectUris === undefined
+    ) {
+      req.session.serviceConfigurationChanges[sid].redirectUris = {};
+      req.session.serviceConfigurationChanges[sid].redirectUris.oldValue =
+        model.service.redirectUris;
+      req.session.serviceConfigurationChanges[sid].redirectUris.newValue =
+        undefined;
+    }
+
+    const newIsServiceHidden = req.body.isServiceHidden === "on";
+    if (newIsServiceHidden !== oldIsServiceHidden) {
+      req.session.serviceConfigurationChanges[sid].isServiceHidden = {
+        oldValue: oldIsServiceHidden ? "Hidden" : "Visible",
+        newValue: newIsServiceHidden ? "Hidden" : "Visible",
+      };
+    }
+
     return res.redirect("review-service-configuration#");
   } catch (error) {
     throw new Error(error);

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -21,6 +21,10 @@ const {
   _unescape,
 } = require("./utils");
 const { decrypt } = require("login.dfe.api-client/encryption");
+const { updateService } = require("../../infrastructure/utils/services");
+
+const isTruthyParam = (value) =>
+  value === true || value === 1 || value === "true" || value === "1";
 
 const buildServiceModelFromObject = (service, sessionService = {}) => {
   let tokenEndpointAuthMethod = null;
@@ -120,9 +124,25 @@ const buildCurrentServiceModel = async (req) => {
     );
     const oldServiceConfigModel = buildServiceModelFromObject(service);
 
+    const allParamsTruthy =
+      isTruthyParam(service.relyingParty?.params?.hideApprover) &&
+      isTruthyParam(service.relyingParty?.params?.hideSupport) &&
+      isTruthyParam(service.relyingParty?.params?.helpHidden);
+    const apiIsServiceHidden =
+      allParamsTruthy &&
+      (!service.isIdOnlyService || isTruthyParam(service.isHiddenService));
+
+    const sessionHideValue = sessionService?.isServiceHidden?.newValue;
+    const isServiceHidden =
+      sessionHideValue !== undefined
+        ? sessionHideValue === "Hidden"
+        : apiIsServiceHidden;
+
     return {
       currentServiceModel,
       oldServiceConfigModel,
+      rawService: service,
+      isServiceHidden,
     };
   } catch (error) {
     throw new Error(`Could not build service model - ${error}`);
@@ -140,7 +160,10 @@ const getServiceConfig = async (req, res) => {
     const serviceModel = await buildCurrentServiceModel(req);
     return res.render("services/views/serviceConfig", {
       csrfToken: req.csrfToken(),
-      service: serviceModel.currentServiceModel,
+      service: {
+        ...serviceModel.currentServiceModel,
+        isServiceHidden: serviceModel.isServiceHidden,
+      },
       backLink: `/services/${sid}`,
       validationMessages: {},
       serviceId: sid,

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -185,6 +185,34 @@
                         <input class="form-control govuk-input" id="postResetUrl" name="postResetUrl" type="text"
                             value="<%-locals.service.postResetUrl%>" />
                     </div>
+
+                    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-4">
+
+                    <div class="govuk-form-group" id="isServiceHidden-form-group">
+                        <fieldset class="govuk-fieldset" aria-describedby="isServiceHidden-hint">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                Hide service
+                            </legend>
+                            <div id="isServiceHidden-hint" class="govuk-hint">
+                                Tick to hide this service from approvers, the help site, and support. Untick to make it visible again.
+                            </div>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input
+                                        class="govuk-checkboxes__input"
+                                        id="isServiceHidden"
+                                        name="isServiceHidden"
+                                        type="checkbox"
+                                        value="on"
+                                        <%= locals.service.isServiceHidden ? 'checked' : '' %>
+                                    >
+                                    <label class="govuk-label govuk-checkboxes__label" for="isServiceHidden">
+                                        Hide this service
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
                 </fieldset>
 
                 <hr class="govuk-section-break govuk-section-break--visible">

--- a/src/constants/serviceConfigConstants.js
+++ b/src/constants/serviceConfigConstants.js
@@ -97,6 +97,13 @@ const amendChangesBaseUrl = `service-configuration?action=${ACTIONS.AMEND_CHANGE
 
 // Service configuration fields and their description displayed in the `Review service configuration changes` page
 const SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS = {
+  isServiceHidden: {
+    title: "Hide service",
+    description:
+      "Whether the service is hidden from approvers, the help site, and support.",
+    changeLink: `${amendChangesBaseUrl}#isServiceHidden-form-group`,
+    displayOrder: 0,
+  },
   serviceHome: {
     title: "Home URL",
     description:

--- a/src/infrastructure/utils/services.js
+++ b/src/infrastructure/utils/services.js
@@ -44,6 +44,9 @@ const updateService = async (serviceId, serviceDetails) => {
     updatedServiceDetails.tokenEndpointAuthMethod =
       serviceDetails.tokenEndpointAuthMethod;
   }
+  if (serviceDetails.isHiddenService !== undefined) {
+    updatedServiceDetails.isHiddenService = serviceDetails.isHiddenService;
+  }
 
   await updateServiceApiClient({
     serviceId: serviceId,

--- a/test/app/services/confirmServiceConfig.get.test.js
+++ b/test/app/services/confirmServiceConfig.get.test.js
@@ -344,4 +344,24 @@ describe("when getting the Review service config changes page", () => {
       "services/views/confirmServiceConfig",
     );
   });
+
+  it("then it should include isServiceHidden in serviceChanges with title 'Hide service'", async () => {
+    req.session.serviceConfigurationChanges[req.params.sid] = {
+      authFlowType: "authorisationCodeFlow",
+      isServiceHidden: {
+        oldValue: "Visible",
+        newValue: "Hidden",
+      },
+    };
+
+    await getConfirmServiceConfig(req, res);
+
+    const { serviceChanges } = res.render.mock.calls[0][1];
+
+    expect(serviceChanges).toBeDefined();
+    const hiddenChange = serviceChanges.find((c) => c.title === "Hide service");
+    expect(hiddenChange).toBeDefined();
+    expect(hiddenChange.addedValues).toContain("Hidden");
+    expect(hiddenChange.removedValues).toContain("Visible");
+  });
 });

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -54,7 +54,6 @@ const {
 const {
   getServiceRaw,
   updateService,
-  updateServiceParam,
 } = require("login.dfe.api-client/services");
 
 const res = getResponseMock();

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -14,6 +14,7 @@ jest.mock("./../../../src/infrastructure/logger", () =>
 jest.mock("login.dfe.api-client/services", () => ({
   getServiceRaw: jest.fn(),
   updateService: jest.fn(),
+  updateServiceParam: jest.fn(),
 }));
 
 jest.mock("../../../src/app/services/utils", () => {
@@ -53,6 +54,7 @@ const {
 const {
   getServiceRaw,
   updateService,
+  updateServiceParam,
 } = require("login.dfe.api-client/services");
 
 const res = getResponseMock();

--- a/test/app/services/confirmServiceConfig.post.test.js
+++ b/test/app/services/confirmServiceConfig.post.test.js
@@ -54,6 +54,7 @@ const {
 const {
   getServiceRaw,
   updateService,
+  updateServiceParam,
 } = require("login.dfe.api-client/services");
 
 const res = getResponseMock();
@@ -832,5 +833,174 @@ describe("when confirming service config changes in the review page", () => {
       "Your changes to service configuration for service one have been saved.",
     );
     expect(res.redirect).toHaveBeenCalledWith("/services/service1");
+  });
+});
+
+describe("hide service save path", () => {
+  const baseSession = {
+    isServiceHidden: { oldValue: "Visible", newValue: "Hidden" },
+    redirectUris: {
+      oldValue: ["https://www.redirect.com"],
+      newValue: undefined,
+    },
+    postLogoutRedirectUris: {
+      oldValue: ["https://www.logout.com"],
+      newValue: undefined,
+    },
+  };
+
+  let req;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getServiceRaw.mockReset();
+    updateService.mockReset();
+    getUserServiceRoles.mockReset();
+    getServiceRaw.mockReturnValue({
+      id: "service1",
+      name: "service one",
+      isIdOnlyService: false,
+      relyingParty: {
+        token_endpoint_auth_method: null,
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "http://service-home.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
+    });
+    getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    updateService.mockResolvedValue(undefined);
+    updateServiceParam.mockResolvedValue(undefined);
+    req = getRequestMock({
+      params: { sid: "service1" },
+      userServices: { roles: [{ code: "service1_serviceconfig" }] },
+      user: { sub: "user1", email: "test@test.com" },
+      session: {
+        serviceConfigurationChanges: {
+          service1: { ...baseSession },
+        },
+      },
+    });
+    res.mockResetAll();
+  });
+
+  it("calls updateServiceParam for hideApprover with 'true' when hiding", async () => {
+    await postConfirmServiceConfig(req, res);
+    expect(updateServiceParam).toHaveBeenCalledWith({
+      serviceId: "service1",
+      paramName: "hideApprover",
+      paramValue: "true",
+    });
+  });
+
+  it("calls updateServiceParam for hideSupport with 'true' when hiding", async () => {
+    await postConfirmServiceConfig(req, res);
+    expect(updateServiceParam).toHaveBeenCalledWith({
+      serviceId: "service1",
+      paramName: "hideSupport",
+      paramValue: "true",
+    });
+  });
+
+  it("calls updateServiceParam for helpHidden with 'true' when hiding", async () => {
+    await postConfirmServiceConfig(req, res);
+    expect(updateServiceParam).toHaveBeenCalledWith({
+      serviceId: "service1",
+      paramName: "helpHidden",
+      paramValue: "true",
+    });
+  });
+
+  it("calls updateServiceParam with 'false' for all three params when showing", async () => {
+    req.session.serviceConfigurationChanges.service1.isServiceHidden = {
+      oldValue: "Hidden",
+      newValue: "Visible",
+    };
+    await postConfirmServiceConfig(req, res);
+    ["hideApprover", "hideSupport", "helpHidden"].forEach((paramName) => {
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: "service1",
+        paramName,
+        paramValue: "false",
+      });
+    });
+  });
+
+  it("does NOT call updateServiceParam when isServiceHidden is not in session", async () => {
+    delete req.session.serviceConfigurationChanges.service1.isServiceHidden;
+    await postConfirmServiceConfig(req, res);
+    expect(updateServiceParam).not.toHaveBeenCalled();
+  });
+
+  it("calls updateService with isHiddenService: 1 for id-only service when hiding", async () => {
+    getServiceRaw.mockReturnValue({
+      id: "service1",
+      name: "service one",
+      isIdOnlyService: true,
+      relyingParty: {
+        token_endpoint_auth_method: null,
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "http://service-home.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
+    });
+    await postConfirmServiceConfig(req, res);
+    expect(updateService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: "service1",
+        update: expect.objectContaining({ isHiddenService: 1 }),
+      }),
+    );
+  });
+
+  it("calls updateService with isHiddenService: 0 for id-only service when showing", async () => {
+    getServiceRaw.mockReturnValue({
+      id: "service1",
+      name: "service one",
+      isIdOnlyService: true,
+      relyingParty: {
+        token_endpoint_auth_method: null,
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "http://service-home.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
+    });
+    req.session.serviceConfigurationChanges.service1.isServiceHidden = {
+      oldValue: "Hidden",
+      newValue: "Visible",
+    };
+    await postConfirmServiceConfig(req, res);
+    expect(updateService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: "service1",
+        update: expect.objectContaining({ isHiddenService: 0 }),
+      }),
+    );
+  });
+
+  it("does NOT call updateService with isHiddenService for role-based service", async () => {
+    // baseService has isIdOnlyService: false
+    await postConfirmServiceConfig(req, res);
+    const isHiddenServiceCalls = updateService.mock.calls.filter(
+      ([args]) => args && args.update && "isHiddenService" in args.update,
+    );
+    expect(isHiddenServiceCalls).toHaveLength(0);
   });
 });

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -29,10 +29,14 @@ jest.mock("../../../src/app/services/utils", () => {
 jest.mock("login.dfe.api-client/services", () => ({
   getServiceRaw: jest.fn(),
 }));
+jest.mock("../../../src/infrastructure/utils/services", () => ({
+  updateService: jest.fn(),
+}));
 
 const { getRequestMock, getResponseMock } = require("../../utils");
 const { getServiceConfig } = require("../../../src/app/services/serviceConfig");
 const { getServiceRaw } = require("login.dfe.api-client/services");
+const { updateService } = require("../../../src/infrastructure/utils/services");
 const { getUserServiceRoles } = require("../../../src/app/services/utils");
 const { ACTIONS } = require("../../../src/constants/serviceConfigConstants");
 
@@ -84,6 +88,7 @@ describe("when getting the service config page", () => {
     });
     getUserServiceRoles.mockReset();
     getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    updateService.mockResolvedValue(undefined);
     res.mockResetAll();
   });
 
@@ -218,6 +223,7 @@ describe("when getting the service config page", () => {
       clientSecret: "new-secret",
       description: "service description",
       grantTypes: ["refresh_token", "authorization_code"],
+      isServiceHidden: false,
       name: "service one",
       postLogoutRedirectUris: "https://new.logout.com",
       postResetUrl: "https://new.postreset.com",
@@ -303,5 +309,124 @@ describe("when getting the service config page", () => {
 
     expect(res.render.mock.calls).toHaveLength(1);
     expect(res.render.mock.calls[0][0]).toBe("services/views/serviceConfig");
+  });
+
+  describe("isServiceHidden checkbox state", () => {
+    const baseService = {
+      id: "service1",
+      name: "service one",
+      description: "service description",
+      isIdOnlyService: false,
+      isHiddenService: false,
+      relyingParty: {
+        token_endpoint_auth_method: null,
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["implicit", "authorization_code"],
+        response_types: ["code"],
+      },
+    };
+
+    it("is false when no params are set", async () => {
+      getServiceRaw.mockReturnValue(baseService);
+      await getServiceConfig(req, res);
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(false);
+    });
+
+    it("is true when all three params are truthy for a role-based service", async () => {
+      getServiceRaw.mockReturnValue({
+        ...baseService,
+        relyingParty: {
+          ...baseService.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+      await getServiceConfig(req, res);
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
+    });
+
+    it("is false when only two of three params are truthy for a role-based service", async () => {
+      getServiceRaw.mockReturnValue({
+        ...baseService,
+        relyingParty: {
+          ...baseService.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "false",
+          },
+        },
+      });
+      await getServiceConfig(req, res);
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(false);
+    });
+
+    it("is true when all three params and isHiddenService are truthy for an id-only service", async () => {
+      getServiceRaw.mockReturnValue({
+        ...baseService,
+        isIdOnlyService: true,
+        isHiddenService: true,
+        relyingParty: {
+          ...baseService.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+      await getServiceConfig(req, res);
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
+    });
+
+    it("is false when all three params truthy but isHiddenService false for an id-only service", async () => {
+      getServiceRaw.mockReturnValue({
+        ...baseService,
+        isIdOnlyService: true,
+        isHiddenService: false,
+        relyingParty: {
+          ...baseService.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+      await getServiceConfig(req, res);
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(false);
+    });
+
+    it("restores isServiceHidden from session during AMEND_CHANGES", async () => {
+      req.query.action = ACTIONS.AMEND_CHANGES;
+      req.session.serviceConfigurationChanges = {
+        [req.params.sid]: {
+          isServiceHidden: { oldValue: "Visible", newValue: "Hidden" },
+        },
+      };
+      getServiceRaw.mockReturnValue({
+        ...baseService,
+        relyingParty: {
+          ...baseService.relyingParty,
+          params: {
+            hideApprover: "false",
+            hideSupport: "false",
+            helpHidden: "false",
+          },
+        },
+      });
+      await getServiceConfig(req, res);
+      // Session says newValue: 'Hidden' → isServiceHidden should be true
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
+    });
   });
 });

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -429,4 +429,131 @@ describe("when getting the service config page", () => {
       expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
     });
   });
+
+  describe("auto-sync isHiddenService for id-only services", () => {
+    const idOnlyServiceBase = {
+      id: "service1",
+      name: "service one",
+      description: "service description",
+      isIdOnlyService: true,
+      relyingParty: {
+        token_endpoint_auth_method: null,
+        client_id: "clientid",
+        client_secret: "dewier-thrombi-confounder-mikado",
+        api_secret: "dewier-thrombi-confounder-mikado",
+        service_home: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+      },
+    };
+
+    beforeEach(() => {
+      updateService.mockResolvedValue(undefined);
+    });
+
+    it("calls updateService with isHiddenService: 1 when params are truthy but isHiddenService is false", async () => {
+      getServiceRaw.mockReturnValue({
+        ...idOnlyServiceBase,
+        isHiddenService: false,
+        relyingParty: {
+          ...idOnlyServiceBase.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+
+      await getServiceConfig(req, res);
+
+      expect(updateService).toHaveBeenCalledWith("service1", {
+        isHiddenService: 1,
+      });
+    });
+
+    it("calls updateService with isHiddenService: 0 when params are falsy but isHiddenService is true", async () => {
+      getServiceRaw.mockReturnValue({
+        ...idOnlyServiceBase,
+        isHiddenService: true,
+        relyingParty: {
+          ...idOnlyServiceBase.relyingParty,
+          params: {
+            hideApprover: "false",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+
+      await getServiceConfig(req, res);
+
+      expect(updateService).toHaveBeenCalledWith("service1", {
+        isHiddenService: 0,
+      });
+    });
+
+    it("does NOT call updateService when params and isHiddenService are consistent", async () => {
+      getServiceRaw.mockReturnValue({
+        ...idOnlyServiceBase,
+        isHiddenService: true,
+        relyingParty: {
+          ...idOnlyServiceBase.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+
+      await getServiceConfig(req, res);
+
+      expect(updateService).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call updateService during AMEND_CHANGES", async () => {
+      req.query.action = ACTIONS.AMEND_CHANGES;
+      req.session.serviceConfigurationChanges = { [req.params.sid]: {} };
+      getServiceRaw.mockReturnValue({
+        ...idOnlyServiceBase,
+        isHiddenService: false,
+        relyingParty: {
+          ...idOnlyServiceBase.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+
+      await getServiceConfig(req, res);
+
+      expect(updateService).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call updateService for a role-based service", async () => {
+      getServiceRaw.mockReturnValue({
+        ...idOnlyServiceBase,
+        isIdOnlyService: false,
+        isHiddenService: false,
+        relyingParty: {
+          ...idOnlyServiceBase.relyingParty,
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      });
+
+      await getServiceConfig(req, res);
+
+      expect(updateService).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -388,7 +388,7 @@ describe("when getting the service config page", () => {
       expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
     });
 
-    it("is false when all three params truthy but isHiddenService false for an id-only service", async () => {
+    it("is true when all three params truthy but isHiddenService false for an id-only service (auto-sync corrects display)", async () => {
       getServiceRaw.mockReturnValue({
         ...baseService,
         isIdOnlyService: true,
@@ -403,7 +403,8 @@ describe("when getting the service config page", () => {
         },
       });
       await getServiceConfig(req, res);
-      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(false);
+      // Auto-sync fires (params truthy but isHiddenService false) and corrects the displayed state.
+      expect(res.render.mock.calls[0][1].service.isServiceHidden).toBe(true);
     });
 
     it("restores isServiceHidden from session during AMEND_CHANGES", async () => {

--- a/test/app/services/postServiceConfig.test.js
+++ b/test/app/services/postServiceConfig.test.js
@@ -889,3 +889,99 @@ describe("when editing the IMPLICIT flow service configuration", () => {
     ).toBe(undefined);
   });
 });
+
+describe("when isServiceHidden checkbox state changes", () => {
+  const baseServiceWithNoParams = {
+    id: "service1",
+    name: "service one",
+    description: "service description",
+    isIdOnlyService: false,
+    isHiddenService: false,
+    relyingParty: {
+      client_id: "clientid",
+      client_secret: "dewier-thrombi-confounder-mikado",
+      service_home: "https://www.servicehome.com",
+      postResetUrl: "https://www.postreset.com",
+      redirect_uris: ["https://www.redirect.com"],
+      post_logout_redirect_uris: ["https://www.logout.com"],
+      grant_types: ["authorization_code", "implicit"],
+      response_types: ["code"],
+      api_secret: "dewier-thrombi-confounder-mikado",
+      token_endpoint_auth_method: undefined,
+      params: {
+        hideApprover: "false",
+        hideSupport: "false",
+        helpHidden: "false",
+      },
+    },
+  };
+
+  let req;
+
+  beforeEach(() => {
+    getServiceRaw.mockReset();
+    getServiceRaw.mockReturnValue(baseServiceWithNoParams);
+    getUserServiceRoles.mockReset();
+    getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    checkClientId.mockReset();
+    checkClientId.mockResolvedValue(null);
+    res.mockResetAll();
+    req = getRequestMock({
+      params: { sid: "service1" },
+      userServices: { roles: [{ code: "service1_serviceconfig" }] },
+      session: {
+        serviceConfigurationChanges: { service1: {} },
+        passport: { user: { sub: "user1" } },
+      },
+      body: {
+        clientId: "clientid",
+        clientSecret: "dewier-thrombi-confounder-mikado",
+        serviceHome: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        response_types: ["code"],
+        isServiceHidden: "on",
+      },
+    });
+  });
+
+  it("writes isServiceHidden to session when checkbox goes from unchecked (Visible) to checked (Hidden)", async () => {
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].isServiceHidden,
+    ).toEqual({ oldValue: "Visible", newValue: "Hidden" });
+  });
+
+  it("writes isServiceHidden to session when checkbox goes from checked (Hidden) to unchecked (Visible)", async () => {
+    getServiceRaw.mockReturnValue({
+      ...baseServiceWithNoParams,
+      relyingParty: {
+        ...baseServiceWithNoParams.relyingParty,
+        params: {
+          hideApprover: "true",
+          hideSupport: "true",
+          helpHidden: "true",
+        },
+      },
+    });
+    req.body.isServiceHidden = undefined;
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].isServiceHidden,
+    ).toEqual({ oldValue: "Hidden", newValue: "Visible" });
+  });
+
+  it("does NOT write isServiceHidden to session when checkbox state is unchanged (both Visible)", async () => {
+    req.body.isServiceHidden = undefined;
+
+    await postServiceConfig(req, res);
+
+    expect(
+      req.session.serviceConfigurationChanges["service1"].isServiceHidden,
+    ).toBeUndefined();
+  });
+});

--- a/test/infrastructure/utils/services.test.js
+++ b/test/infrastructure/utils/services.test.js
@@ -1,0 +1,45 @@
+jest.mock("login.dfe.api-client/services", () => ({
+  updateService: jest.fn(),
+}));
+
+const {
+  updateService: updateServiceApiClient,
+} = require("login.dfe.api-client/services");
+const {
+  updateService,
+} = require("./../../../src/infrastructure/utils/services");
+
+describe("updateService", () => {
+  beforeEach(() => {
+    updateServiceApiClient.mockReset();
+  });
+
+  it("should pass isHiddenService to the api-client when provided as 1", async () => {
+    await updateService("service1", { isHiddenService: 1 });
+
+    expect(updateServiceApiClient).toHaveBeenCalledWith({
+      serviceId: "service1",
+      update: { isHiddenService: 1 },
+    });
+  });
+
+  it("should pass isHiddenService to the api-client when provided as 0", async () => {
+    await updateService("service1", { isHiddenService: 0 });
+
+    expect(updateServiceApiClient).toHaveBeenCalledWith({
+      serviceId: "service1",
+      update: { isHiddenService: 0 },
+    });
+  });
+
+  it("should NOT include isHiddenService in the update when not provided", async () => {
+    await updateService("service1", { name: "My Service" });
+
+    expect(updateServiceApiClient).toHaveBeenCalledWith({
+      serviceId: "service1",
+      update: { name: "My Service" },
+    });
+    const calledWith = updateServiceApiClient.mock.calls[0][0];
+    expect(calledWith.update).not.toHaveProperty("isHiddenService");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Hide Service** checkbox to the Service Details section of the edit service configuration page
- Previously, hiding a service required a direct database script; this exposes the toggle via the Manage Console UI
- Sets `hideApprover`, `hideSupport`, and `helpHidden` params on save; additionally syncs `isHiddenService` for id-only services

## How it works

**Checkbox state on page load**
Checked when all three of `hideApprover`, `hideSupport`, and `helpHidden` are truthy. For id-only services, `isHiddenService` must also be truthy. If any condition is unmet, the checkbox shows unchecked.

If `isHiddenService` is inconsistent with the three params on an id-only service (legacy data), it is silently corrected via a background call on page load.

**On save**
Flows through the existing review-and-confirm pattern. The review page shows the pending change before the user confirms. On confirm:
- `updateServiceParam` sets `hideApprover`, `hideSupport`, and `helpHidden` to `"true"`/`"false"` for all service types
- For id-only services, `updateService` additionally sets `isHiddenService` to `1`/`0`

## Notes

> **⚠️ Deployment dependency** - `login.dfe.applications` ([feature/NSA-9688-hide-service-param-upsert](https://github.com/DFE-Digital/login.dfe.applications)) **must be deployed before this PR**. It adds upsert behaviour to `PUT /services/:id/params/:key`. Without it, the save path will error on any service where a hide param has never previously been set.

**Related PRs (must all be deployed for full feature)**
- `login.dfe.applications` - `feature/NSA-9688-hide-service-param-upsert`
- `login.dfe.help-git` - `feature/NSA-9688-hide-service-checkbox`
- `login.dfe.support` - `feature/NSA-9688-hide-service-checkbox`
- `login.dfe.services` - `feature/NSA-9688-hide-service-checkbox`

## Test plan

- [ ] Role-based service with no hide params set - checkbox shows **unchecked**
- [ ] Check the checkbox → Continue → review page shows **"Hide service — Added: Hidden"** → Save → checkbox shows **checked** on reload
- [ ] Uncheck the checkbox → Save → checkbox shows **unchecked** on reload
- [ ] Service previously hidden via DB script (all three params `"true"`) - checkbox shows **checked** on page load
- [ ] Id-only service where `isHiddenService = 1` but params are inconsistent - **auto-sync** corrects on page load
- [ ] Id-only service - hide via checkbox, save → `isHiddenService` updated alongside the three params
- [ ] Make an OIDC change and a hide change in the same save - **both** appear on the review page and both save correctly
- [ ] Trigger a validation error after checking the Hide Service box - **checkbox remains checked** on the error re-render
