### PR TITLE
fix(NSA-9812): prevent horizontal overflow for 250-char alphanumeric role names

### DIFF
--- a/src/app/services/views/confirmCreateNewPolicy.ejs
+++ b/src/app/services/views/confirmCreateNewPolicy.ejs
@@ -17,7 +17,7 @@
           <dt class="govuk-summary-list__key">
             Name
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
             <%= model.name %>
           </dd>
           <dd class="govuk-summary-list__actions">
@@ -31,7 +31,7 @@
           <dt class="govuk-summary-list__key">
             Name
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
               <%= model.role.roleName %>
           </dd>
           <dd class="govuk-summary-list__actions">
@@ -42,7 +42,7 @@
           <dt class="govuk-summary-list__key">
             Code
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
               <%= model.role.roleCode %>
           </dd>
           <dd class="govuk-summary-list__actions">
@@ -57,7 +57,7 @@
           <dt class="govuk-summary-list__key">
             Condition
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
               <%= model.condition.condition %>
           </dd>
           <dd class="govuk-summary-list__actions">
@@ -68,7 +68,7 @@
           <dt class="govuk-summary-list__key">
             Operator
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
               <%= model.condition.operator %>
           </dd>
           <dd class="govuk-summary-list__actions">
@@ -79,7 +79,7 @@
           <dt class="govuk-summary-list__key">
             Value
           </dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
               <%= model.condition.value %>
           </dd>
           <dd class="govuk-summary-list__actions">

--- a/src/app/services/views/confirmCreatePolicyRole.ejs
+++ b/src/app/services/views/confirmCreatePolicyRole.ejs
@@ -9,9 +9,9 @@
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">
-                        Role name   
+                        Role name
                     </dt>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
                         <p class="govuk-body"><%=locals.roleName%></p>
                     </dd>
                 </div>
@@ -19,7 +19,7 @@
                     <dt class="govuk-summary-list__key">
                         Role code
                     </dt>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
                         <p class="govuk-body"><%= locals.roleCode%></p>
                     </dd>
                 </div>

--- a/src/app/services/views/confirmRemovePolicyRole.ejs
+++ b/src/app/services/views/confirmRemovePolicyRole.ejs
@@ -10,9 +10,9 @@
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">
-                        Name   
+                        Name
                     </dt>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
                         <%=locals.name%>
                     </dd>
                 </div>
@@ -20,7 +20,7 @@
                     <dt class="govuk-summary-list__key">
                         Code
                     </dt>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__value" style="word-break: break-all; overflow-wrap: anywhere;">
                         <%= locals.code%>
                     </dd>
                 </div>

--- a/src/app/services/views/listRoles.ejs
+++ b/src/app/services/views/listRoles.ejs
@@ -8,7 +8,7 @@
                 </h2>
             </div>
             <div class="govuk-notification-banner__content">
-                <p class="govuk-body">
+                <p class="govuk-body" style="word-break: break-all; overflow-wrap: anywhere;">
                     <%=locals.flash.info%>
                 </p>
             </div>
@@ -23,7 +23,7 @@
                 </h2>
             </div>
             <div class="govuk-notification-banner__content">
-                <p class="govuk-body">
+                <p class="govuk-body" style="word-break: break-all; overflow-wrap: anywhere;">
                     <%=locals.flash.error%>
                 </p>
             </div>
@@ -50,11 +50,11 @@
 
     <div class="govuk-grid-row govuk-!-margin-top-6">
         <div class="govuk-grid-column-full">
-            <table class="govuk-table">
+            <table class="govuk-table" style="table-layout: fixed; width: 100%;">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row sortable">
-                        <th scope="col" class="govuk-table__header width-55">Name</th>
-                        <th scope="col" class="govuk-table__header width-20">Policies</th>
+                        <th scope="col" class="govuk-table__header" style="width: 80%;">Name</th>
+                        <th scope="col" class="govuk-table__header" style="width: 20%;">Policies</th>
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
@@ -71,7 +71,7 @@
                     const role = locals.roles[i];
                 %>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
+                        <td class="govuk-table__cell" style="word-break: break-all; overflow-wrap: anywhere;">
                             <%= role.name %>
                         </td>
                         <td class="govuk-table__cell">

--- a/src/app/services/views/policyConditionsAndRoles.ejs
+++ b/src/app/services/views/policyConditionsAndRoles.ejs
@@ -8,7 +8,7 @@
                 </h2>
             </div>
             <div class="govuk-notification-banner__content">
-                <p class="govuk-body">
+                <p class="govuk-body" style="word-break: break-all; overflow-wrap: anywhere;">
                     <%=locals.flash.info%>
                 </p>
             </div>
@@ -23,7 +23,7 @@
                 </h2>
             </div>
             <div class="govuk-notification-banner__content">
-                <p class="govuk-body">
+                <p class="govuk-body" style="word-break: break-all; overflow-wrap: anywhere;">
                     <%=locals.flash.error%>
                 </p>
             </div>
@@ -162,9 +162,9 @@
                         <% for (let i = 0; i < locals.policy.roles.length; i++) { %>
                             <% const role = locals.policy.roles[i];%>
                             <tr class="govuk-table__row">
-                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.name %></td>
-                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.code %></td>
-                                <td class="govuk-table__cell" style="overflow-wrap: break-word;"><%= role.numericId %></td>
+                                <td class="govuk-table__cell" style="word-break: break-all; overflow-wrap: anywhere;"><%= role.name %></td>
+                                <td class="govuk-table__cell" style="word-break: break-all; overflow-wrap: anywhere;"><%= role.code %></td>
+                                <td class="govuk-table__cell" style="word-break: break-all; overflow-wrap: anywhere;"><%= role.numericId %></td>
                                 <td class="govuk-table__cell govuk-table__cell--numeric"><%= role.status ? role.status.id : '' %></td>
                                 <%  if (locals.canUserModifyPolicyConditionsAndRoles) { %>
                                     <td class="govuk-table__cell">


### PR DESCRIPTION
## Summary
- Replace `overflow-wrap: break-word` with `word-break: break-all; overflow-wrap: anywhere;` on the three role data cells in `policyConditionsAndRoles.ejs` - the old property failed for pure alphanumeric strings with no natural break opportunities
- Apply `table-layout: fixed; width: 100%`, inline column widths (80%/20%), and `word-break: break-all; overflow-wrap: anywhere;` on the Name cell in `listRoles.ejs` - this page had no overflow protection at all, causing horizontal scrollbar and hiding content after creating a long alphanumeric role

## Test Plan
- [x] Navigate to a service's Roles page (`/services/:sid/roles`) with a 250-char alphanumeric role name - no horizontal scrollbar, name wraps within column
- [x] Navigate to a policy's Conditions & Roles page - 250-char alphanumeric name wraps within Name column, Remove link visible and clickable
- [x] Click Remove on the 250-char alphanumeric role - confirmation page loads, removal succeeds
- [x] Verify existing passing cases (special chars, names with spaces) still pass
- [x] `npm test` - 605 tests pass
