### PR TITLE
NSA-9832: fix policy role creation redirect to return to policy page

### DIFF
--- a/src/app/services/postConfirmCreatePolicyRole.js
+++ b/src/app/services/postConfirmCreatePolicyRole.js
@@ -176,7 +176,9 @@ const postConfirmCreatePolicyRole = async (req, res) => {
       `Policy role ${model.roleName} ${model.roleCode} successfully added`,
     );
   }
-  return res.redirect(`/services/${req.params.sid}/roles`);
+  return res.redirect(
+    `/services/${req.params.sid}/policies/${req.params.pid}/conditionsAndRoles`,
+  );
 };
 
 module.exports = postConfirmCreatePolicyRole;

--- a/test/app/services/postConfirmCreatePolicyRole.test.js
+++ b/test/app/services/postConfirmCreatePolicyRole.test.js
@@ -154,7 +154,9 @@ describe("when using the postConfirmCreatePolicyRole function", () => {
     });
 
     expect(res.redirect.mock.calls.length).toBe(1);
-    expect(res.redirect.mock.calls[0][0]).toBe("/services/service-1/roles");
+    expect(res.redirect.mock.calls[0][0]).toBe(
+      "/services/service-1/policies/policy-1/conditionsAndRoles",
+    );
     expect(res.flash).toHaveBeenCalledWith(
       "info",
       "Policy role New Test Role new_test_role successfully added",
@@ -215,7 +217,9 @@ describe("when using the postConfirmCreatePolicyRole function", () => {
       serviceId: "service-1",
     });
 
-    expect(res.redirect.mock.calls[0][0]).toBe("/services/service-1/roles");
+    expect(res.redirect.mock.calls[0][0]).toBe(
+      "/services/service-1/policies/policy-1/conditionsAndRoles",
+    );
     expect(res.flash).toHaveBeenCalledWith(
       "info",
       "Policy role Existing Role existing_role successfully added",

--- a/test/app/services/serviceRoles.createRedirect.flow.test.js
+++ b/test/app/services/serviceRoles.createRedirect.flow.test.js
@@ -67,7 +67,7 @@ describe("service role create to service roles route flow", () => {
     ]);
   });
 
-  it("redirects to service roles route and provides nav context for the destination page", async () => {
+  it("redirects to the policy conditions and roles page after creating a policy role", async () => {
     const postReq = getRequestMock({
       params: {
         sid: "service-1",
@@ -85,7 +85,9 @@ describe("service role create to service roles route flow", () => {
 
     await postConfirmCreatePolicyRole(postReq, postRes);
 
-    expect(postRes.redirect).toHaveBeenCalledWith("/services/service-1/roles");
+    expect(postRes.redirect).toHaveBeenCalledWith(
+      "/services/service-1/policies/policy-1/conditionsAndRoles",
+    );
 
     const getReq = getRequestMock({
       params: {


### PR DESCRIPTION
## Summary
- After confirming a new policy role, redirect to the policy's conditions and roles page (`/policies/:pid/conditionsAndRoles`) instead of the service roles list (`/roles`)
- Updated tests to assert the corrected redirect URL

## Test plan
- [ ] Create a new policy role via Manage console and confirm creation redirects to the policy's conditions and roles page
- [ ] Verify existing policy role tests pass (`npm test -- --testPathPattern=postConfirmCreatePolicyRole`)

Fixes NSA-9832