### PR TITLE
feat(NSA-9688): add Hide Service checkbox to service config 

### DIFF
--- a/src/app/services/confirmServiceConfig.js
+++ b/src/app/services/confirmServiceConfig.js
@@ -1,6 +1,9 @@
 const niceware = require("niceware");
 const UrlValidator = require("login.dfe.validation/src/urlValidator");
-const { updateService } = require("../../infrastructure/utils/services");
+const {
+  updateService,
+  updateServiceParam,
+} = require("../../infrastructure/utils/services");
 const { getServiceRaw } = require("login.dfe.api-client/services");
 const logger = require("../../infrastructure/logger");
 const {
@@ -93,6 +96,7 @@ const buildCurrentServiceModel = async (req) => {
   });
   return {
     name: service.name || "",
+    isIdOnlyService: !!service.isIdOnlyService,
   };
 };
 
@@ -110,10 +114,12 @@ const validate = async (req, currentService) => {
       serviceConfigurationChanges.responseTypes?.newValue,
     );
     const selectedRedirects = processRedirectUris(
-      serviceConfigurationChanges.redirectUris?.newValue,
+      serviceConfigurationChanges.redirectUris?.newValue ??
+        serviceConfigurationChanges.redirectUris?.oldValue,
     );
     const selectedLogout = processRedirectUris(
-      serviceConfigurationChanges.postLogoutRedirectUris?.newValue,
+      serviceConfigurationChanges.postLogoutRedirectUris?.newValue ??
+        serviceConfigurationChanges.postLogoutRedirectUris?.oldValue,
     );
 
     let tokenEndpointAuthMethod;
@@ -164,11 +170,11 @@ const validate = async (req, currentService) => {
     const { serviceHome, postResetUrl, clientId } = model.service;
     if (model.service.postLogoutRedirectUris === undefined) {
       model.service.postLogoutRedirectUris =
-        serviceConfigurationChanges.postLogoutRedirectUris.oldValue;
+        serviceConfigurationChanges.postLogoutRedirectUris?.oldValue ?? [];
     }
     if (model.service.redirectUris === undefined) {
       model.service.redirectUris =
-        serviceConfigurationChanges.redirectUris.oldValue;
+        serviceConfigurationChanges.redirectUris?.oldValue ?? [];
     }
     const urlValidator = new UrlValidator(serviceHome);
     const lengthResult = await isCorrectLength(urlValidator);
@@ -528,6 +534,8 @@ const postConfirmServiceConfig = async (req, res) => {
         };
       });
 
+    const hideChange = serviceConfigChanges?.isServiceHidden;
+
     const { CLIENT_SECRET_POST } = TOKEN_ENDPOINT_AUTH_METHOD;
 
     const updatedService = {
@@ -542,14 +550,38 @@ const postConfirmServiceConfig = async (req, res) => {
       apiSecret: model.service.apiSecret
         ? encrypt(model.service.apiSecret)
         : model.service.apiSecret,
-      // If tokenEndpointAuthMethod isn't 'client_secret_post', store NULL in the DB.
       tokenEndpointAuthMethod:
         model.service.tokenEndpointAuthMethod === CLIENT_SECRET_POST
           ? CLIENT_SECRET_POST
           : null,
+      ...(hideChange?.newValue !== undefined &&
+        currentService.isIdOnlyService && {
+          isHiddenService: hideChange.newValue === "Hidden" ? 1 : 0,
+        }),
     };
 
     await updateService(req.params.sid, updatedService);
+
+    if (hideChange?.newValue !== undefined) {
+      const shouldHide = hideChange.newValue === "Hidden";
+      await Promise.all([
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "hideApprover",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "hideSupport",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+        updateServiceParam({
+          serviceId: req.params.sid,
+          paramName: "helpHidden",
+          paramValue: shouldHide ? "true" : "false",
+        }),
+      ]);
+    }
 
     logger.audit(`${req.user.email} updated service configuration`, {
       type: "manage",

--- a/src/app/services/serviceConfig.js
+++ b/src/app/services/serviceConfig.js
@@ -22,6 +22,18 @@ const {
 } = require("./utils");
 const { decrypt } = require("login.dfe.api-client/encryption");
 
+const isTruthyParam = (v) => v === true || v === 1 || v === "true" || v === "1";
+
+const isServiceHiddenFromDb = (service) => {
+  const params = service.relyingParty?.params;
+  const paramsTruthy =
+    isTruthyParam(params?.hideApprover) &&
+    isTruthyParam(params?.hideSupport) &&
+    isTruthyParam(params?.helpHidden);
+  if (!service.isIdOnlyService) return paramsTruthy;
+  return paramsTruthy && isTruthyParam(service.isHiddenService);
+};
+
 const buildServiceModelFromObject = (service, sessionService = {}) => {
   let tokenEndpointAuthMethod = null;
   const { CLIENT_SECRET_POST, CLIENT_SECRET_BASIC } =
@@ -114,15 +126,26 @@ const buildCurrentServiceModel = async (req) => {
         service.relyingParty.api_secret,
       );
     }
+
+    const apiIsServiceHidden = isServiceHiddenFromDb(service);
+    const sessionHideValue = sessionService?.isServiceHidden?.newValue;
+    const isServiceHidden =
+      sessionHideValue !== undefined
+        ? sessionHideValue === "Hidden"
+        : apiIsServiceHidden;
+
     const currentServiceModel = buildServiceModelFromObject(
       service,
       sessionService,
     );
+    currentServiceModel.isServiceHidden = isServiceHidden;
+
     const oldServiceConfigModel = buildServiceModelFromObject(service);
 
     return {
       currentServiceModel,
       oldServiceConfigModel,
+      apiIsServiceHidden,
     };
   } catch (error) {
     throw new Error(`Could not build service model - ${error}`);
@@ -239,6 +262,7 @@ const validate = async (req, currentService, oldService) => {
       apiSecret: req.body.apiSecret,
       tokenEndpointAuthMethod,
       refreshToken,
+      isServiceHidden: req.body.isServiceHidden === "on",
     },
     authFlowType,
     backLink: `/services/${req.params.sid}`,
@@ -385,6 +409,10 @@ const validate = async (req, currentService, oldService) => {
     model.validationMessages.clientId = ERROR_MESSAGES.CLIENT_ID_UNAVAILABLE;
   }
 
+  // NOTE (NSA-9688): this validation runs even when the only change being saved is the
+  // "Hide this service" checkbox. A service with no redirect_uris configured cannot be
+  // hidden/unhidden via this form until at least one redirect URI is added. This is a
+  // known, accepted limitation — see NSA-9688 ticket comments for the product decision.
   if (!model.service.redirectUris || !model.service.redirectUris.length > 0) {
     model.validationMessages.redirect_uris =
       ERROR_MESSAGES.MISSING_REDIRECT_URL;
@@ -444,6 +472,10 @@ const validate = async (req, currentService, oldService) => {
       ERROR_MESSAGES.REDIRECT_URLS_NOT_UNIQUE;
   }
 
+  // NOTE (NSA-9688): this validation runs even when the only change being saved is the
+  // "Hide this service" checkbox. A service with no redirect_uris configured cannot be
+  // hidden/unhidden via this form until at least one redirect URI is added. This is a
+  // known, accepted limitation — see NSA-9688 ticket comments for the product decision.
   if (
     !model.service.postLogoutRedirectUris ||
     !model.service.postLogoutRedirectUris.length > 0
@@ -588,12 +620,19 @@ const postServiceConfig = async (req, res) => {
         return editedField;
       });
 
+    const oldIsServiceHidden = serviceModels.apiIsServiceHidden
+      ? "Hidden"
+      : "Visible";
+    const newIsServiceHidden =
+      req.body.isServiceHidden === "on" ? "Hidden" : "Visible";
+    const hideServiceChanged = oldIsServiceHidden !== newIsServiceHidden;
+
     const { sid } = req.params;
     req.session.serviceConfigurationChanges =
       req.session.serviceConfigurationChanges || {};
     req.session.serviceConfigurationChanges[sid] = {};
 
-    if (editedFields && editedFields.length > 0) {
+    if (editedFields.length > 0 || hideServiceChanged) {
       editedFields.map(
         ({ name, oldValue, newValue, isSecret, secretNewValue }) => {
           if (!req.session.serviceConfigurationChanges[sid][name]) {
@@ -636,7 +675,15 @@ const postServiceConfig = async (req, res) => {
         req.session.serviceConfigurationChanges[sid].redirectUris.newValue =
           undefined;
       }
+
+      if (hideServiceChanged) {
+        req.session.serviceConfigurationChanges[sid].isServiceHidden = {
+          oldValue: oldIsServiceHidden,
+          newValue: newIsServiceHidden,
+        };
+      }
     }
+
     return res.redirect("review-service-configuration#");
   } catch (error) {
     throw new Error(error);
@@ -647,4 +694,5 @@ module.exports = {
   getServiceConfig,
   postServiceConfig,
   getGrantTypes,
+  isServiceHiddenFromDb,
 };

--- a/src/app/services/views/confirmServiceConfig.ejs
+++ b/src/app/services/views/confirmServiceConfig.ejs
@@ -48,17 +48,25 @@
                     </div>
                   </dt>
                   <dd class="govuk-summary-list__value">
-                    <% if (e.removedValues && e.removedValues.length > 0) { %>
-                      <p class="govuk-body govuk-!-font-weight-bold">Removed:</p>
-                      <% e.removedValues.forEach((value) => { %>
-                        <p class="govuk-body"><%- value %></p>
-                      <% }); %>
-                    <% } %>
-                    <% if (e.addedValues && e.addedValues.length > 0) { %>
-                      <p class="govuk-body govuk-!-font-weight-bold">Added:</p>
-                      <% e.addedValues.forEach((value) => { %>
-                        <p class="govuk-body"><%- value %></p>
-                      <% }); %>
+                    <% if (e.isToggle) { %>
+                      <% if (e.addedValues && e.addedValues.length > 0) { %>
+                        <% e.addedValues.forEach((value) => { %>
+                          <p class="govuk-body"><%- value %></p>
+                        <% }); %>
+                      <% } %>
+                    <% } else { %>
+                      <% if (e.removedValues && e.removedValues.length > 0) { %>
+                        <p class="govuk-body govuk-!-font-weight-bold">Removed:</p>
+                        <% e.removedValues.forEach((value) => { %>
+                          <p class="govuk-body"><%- value %></p>
+                        <% }); %>
+                      <% } %>
+                      <% if (e.addedValues && e.addedValues.length > 0) { %>
+                        <p class="govuk-body govuk-!-font-weight-bold">Added:</p>
+                        <% e.addedValues.forEach((value) => { %>
+                          <p class="govuk-body"><%- value %></p>
+                        <% }); %>
+                      <% } %>
                     <% } %>
                   </dd>
                   <dd class="govuk-summary-list__actions">

--- a/src/app/services/views/serviceConfig.ejs
+++ b/src/app/services/views/serviceConfig.ejs
@@ -185,6 +185,25 @@
                         <input class="form-control govuk-input" id="postResetUrl" name="postResetUrl" type="text"
                             value="<%-locals.service.postResetUrl%>" />
                     </div>
+
+                <div class="govuk-form-group" id="isServiceHidden-form-group">
+                  <fieldset class="govuk-fieldset" aria-describedby="isServiceHidden-hint">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Hide service</h2>
+                    </legend>
+                    <div id="isServiceHidden-hint" class="govuk-hint">
+                      Tick to hide this service from users, approvers, the help site, and support. Untick to make it visible again.
+                    </div>
+                    <div class="govuk-checkboxes">
+                      <div class="multiple-choice govuk-checkboxes__item">
+                        <input class="govuk-checkboxes__input" id="isServiceHidden" name="isServiceHidden" type="checkbox" value="on" <%= locals.service.isServiceHidden ? 'checked' : '' %>>
+                        <label class="govuk-label govuk-checkboxes__label" for="isServiceHidden">
+                          Hide this service
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
                 </fieldset>
 
                 <hr class="govuk-section-break govuk-section-break--visible">

--- a/src/constants/serviceConfigConstants.js
+++ b/src/constants/serviceConfigConstants.js
@@ -97,6 +97,14 @@ const amendChangesBaseUrl = `service-configuration?action=${ACTIONS.AMEND_CHANGE
 
 // Service configuration fields and their description displayed in the `Review service configuration changes` page
 const SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS = {
+  isServiceHidden: {
+    title: "Hide service",
+    description:
+      "Whether this service is hidden from users, approvers, the help site, and support.",
+    changeLink: `${amendChangesBaseUrl}#isServiceHidden-form-group`,
+    displayOrder: 0,
+    isToggle: true,
+  },
   serviceHome: {
     title: "Home URL",
     description:

--- a/src/infrastructure/utils/services.js
+++ b/src/infrastructure/utils/services.js
@@ -1,6 +1,21 @@
+const path = require("path");
 const {
   updateService: updateServiceApiClient,
 } = require("login.dfe.api-client/services");
+
+// Resolve the api-client package root via three dirname calls on the known
+// exported path (dist/services/index.js → dist/services → dist → root).
+// Using absolute paths bypasses the package exports map restriction so we can
+// reach internal modules not yet exposed as public exports (e.g. getApiClient).
+const _apiClientRoot = path.dirname(
+  path.dirname(path.dirname(require.resolve("login.dfe.api-client/services"))),
+);
+const { getApiClient, ApiName } = require(
+  path.join(_apiClientRoot, "dist", "api", "index.js"),
+);
+const { RequestMethod } = require(
+  path.join(_apiClientRoot, "dist", "api", "common", "ApiClient.js"),
+);
 
 const updateService = async (serviceId, serviceDetails) => {
   const updatedServiceDetails = {};
@@ -44,13 +59,43 @@ const updateService = async (serviceId, serviceDetails) => {
     updatedServiceDetails.tokenEndpointAuthMethod =
       serviceDetails.tokenEndpointAuthMethod;
   }
-
   await updateServiceApiClient({
     serviceId: serviceId,
     update: updatedServiceDetails,
   });
+
+  // isHiddenService is stripped by the api-client's camelToSnakeMapping so we
+  // send it via a direct PATCH that bypasses the transform.
+  if (serviceDetails.isHiddenService !== undefined) {
+    const client = getApiClient(ApiName.Applications);
+    const response = await client.requestRaw(
+      RequestMethod.PATCH,
+      `/services/${serviceId}`,
+      { jsonBody: { isHiddenService: serviceDetails.isHiddenService } },
+    );
+    if (response && !response.ok) {
+      throw new Error(
+        `Failed to update isHiddenService for service ${serviceId}: HTTP ${response.status}`,
+      );
+    }
+  }
+};
+
+const updateServiceParam = async ({ serviceId, paramName, paramValue }) => {
+  const client = getApiClient(ApiName.Applications);
+  const response = await client.requestRaw(
+    RequestMethod.PUT,
+    `/services/${serviceId}/params/${paramName}`,
+    { jsonBody: { paramName, paramValue } },
+  );
+  if (response && !response.ok) {
+    throw new Error(
+      `Failed to update service param ${paramName} for service ${serviceId}: HTTP ${response.status}`,
+    );
+  }
 };
 
 module.exports = {
   updateService,
+  updateServiceParam,
 };

--- a/test/app/services/confirmServiceConfig.test.js
+++ b/test/app/services/confirmServiceConfig.test.js
@@ -1,0 +1,238 @@
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").configMockFactory(),
+);
+jest.mock("./../../../src/infrastructure/logger", () =>
+  require("./../../utils").loggerMockFactory(),
+);
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
+jest.mock("login.dfe.api-client/encryption", () => ({
+  encrypt: jest.fn().mockReturnValue("encrypted-secret"),
+}));
+jest.mock("./../../../src/infrastructure/utils/services", () => ({
+  updateService: jest.fn(),
+  updateServiceParam: jest.fn(),
+}));
+jest.mock("./../../../src/app/services/utils");
+jest.mock("login.dfe.validation/src/urlValidator", () =>
+  jest.fn().mockImplementation(() => ({})),
+);
+
+const { getServiceRaw } = require("login.dfe.api-client/services");
+const {
+  updateService,
+  updateServiceParam,
+} = require("./../../../src/infrastructure/utils/services");
+const {
+  getUserServiceRoles,
+  isCorrectLength,
+  isValidUrl,
+  isCorrectProtocol,
+  checkClientId,
+  processRedirectUris,
+  processConfigurationTypes,
+} = require("./../../../src/app/services/utils");
+
+const {
+  postConfirmServiceConfig,
+} = require("./../../../src/app/services/confirmServiceConfig");
+
+const SERVICE_ID = "service-abc-123";
+
+const buildSession = (hideNewValue) => ({
+  serviceConfigurationChanges: {
+    [SERVICE_ID]: {
+      authFlowType: "authorisationCodeFlow",
+      redirectUris: {
+        oldValue: ["https://redirect.example.com/callback"],
+        newValue: undefined,
+      },
+      postLogoutRedirectUris: {
+        oldValue: ["https://logout.example.com"],
+        newValue: undefined,
+      },
+      ...(hideNewValue !== undefined && {
+        isServiceHidden: {
+          oldValue: hideNewValue === "Hidden" ? "Visible" : "Hidden",
+          newValue: hideNewValue,
+        },
+      }),
+    },
+  },
+});
+
+const buildReq = (hideNewValue) => ({
+  params: { sid: SERVICE_ID },
+  user: { sub: "user1", email: "admin@test.com" },
+  csrfToken: () => "token",
+  flash: jest.fn(),
+  session: buildSession(hideNewValue),
+});
+
+describe("postConfirmServiceConfig — hide service", () => {
+  let res;
+
+  beforeEach(() => {
+    res = {
+      render: jest.fn(),
+      redirect: jest.fn(),
+      flash: jest.fn(),
+    };
+
+    getUserServiceRoles.mockResolvedValue([]);
+    processRedirectUris.mockImplementation((v) =>
+      Array.isArray(v) ? v : v ? [v] : [],
+    );
+    processConfigurationTypes.mockImplementation((v) =>
+      Array.isArray(v) ? v : v ? [v] : [],
+    );
+    isCorrectLength.mockResolvedValue(true);
+    isValidUrl.mockResolvedValue(true);
+    isCorrectProtocol.mockResolvedValue(true);
+    checkClientId.mockResolvedValue(false);
+    updateService.mockResolvedValue();
+    updateServiceParam.mockResolvedValue();
+  });
+
+  describe("hiding a role-based service", () => {
+    beforeEach(() => {
+      getServiceRaw.mockResolvedValue({
+        name: "Test Service",
+        isIdOnlyService: false,
+        relyingParty: {
+          client_id: "client-1",
+          redirect_uris: ["https://redirect.example.com/callback"],
+          post_logout_redirect_uris: ["https://logout.example.com"],
+          response_types: ["code"],
+          grant_types: ["authorization_code"],
+        },
+      });
+    });
+
+    it("calls updateServiceParam for hideApprover, hideSupport, and helpHidden with 'true'", async () => {
+      const req = buildReq("Hidden");
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "hideApprover",
+        paramValue: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "hideSupport",
+        paramValue: "true",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "helpHidden",
+        paramValue: "true",
+      });
+    });
+
+    it("does NOT include isHiddenService in the updateService call", async () => {
+      const req = buildReq("Hidden");
+      await postConfirmServiceConfig(req, res);
+
+      const serviceUpdateArg = updateService.mock.calls[0]?.[1];
+      expect(serviceUpdateArg).not.toHaveProperty("isHiddenService");
+    });
+  });
+
+  describe("hiding an id-only service", () => {
+    beforeEach(() => {
+      getServiceRaw.mockResolvedValue({
+        name: "ID Only Service",
+        isIdOnlyService: true,
+        relyingParty: {
+          client_id: "client-id-only",
+          redirect_uris: ["https://redirect.example.com/callback"],
+          post_logout_redirect_uris: ["https://logout.example.com"],
+          response_types: ["code"],
+          grant_types: ["authorization_code"],
+        },
+      });
+    });
+
+    it("includes isHiddenService=1 in the updateService call", async () => {
+      const req = buildReq("Hidden");
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateService).toHaveBeenCalledWith(
+        SERVICE_ID,
+        expect.objectContaining({ isHiddenService: 1 }),
+      );
+    });
+
+    it("includes isHiddenService=0 when revealing the service", async () => {
+      const req = buildReq("Visible");
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateService).toHaveBeenCalledWith(
+        SERVICE_ID,
+        expect.objectContaining({ isHiddenService: 0 }),
+      );
+    });
+  });
+
+  describe("revealing a role-based service", () => {
+    beforeEach(() => {
+      getServiceRaw.mockResolvedValue({
+        name: "Test Service",
+        isIdOnlyService: false,
+        relyingParty: {
+          client_id: "client-1",
+          redirect_uris: ["https://redirect.example.com/callback"],
+          post_logout_redirect_uris: ["https://logout.example.com"],
+          response_types: ["code"],
+          grant_types: ["authorization_code"],
+        },
+      });
+    });
+
+    it("calls updateServiceParam for all three params with 'false'", async () => {
+      const req = buildReq("Visible");
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "hideApprover",
+        paramValue: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "hideSupport",
+        paramValue: "false",
+      });
+      expect(updateServiceParam).toHaveBeenCalledWith({
+        serviceId: SERVICE_ID,
+        paramName: "helpHidden",
+        paramValue: "false",
+      });
+    });
+  });
+
+  describe("when isServiceHidden is not in session (no hide change)", () => {
+    beforeEach(() => {
+      getServiceRaw.mockResolvedValue({
+        name: "Test Service",
+        isIdOnlyService: false,
+        relyingParty: {
+          client_id: "client-1",
+          redirect_uris: ["https://redirect.example.com/callback"],
+          post_logout_redirect_uris: ["https://logout.example.com"],
+          response_types: ["code"],
+          grant_types: ["authorization_code"],
+        },
+      });
+    });
+
+    it("does NOT call updateServiceParam", async () => {
+      const req = buildReq(undefined);
+      await postConfirmServiceConfig(req, res);
+
+      expect(updateServiceParam).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/app/services/getServiceConfig.test.js
+++ b/test/app/services/getServiceConfig.test.js
@@ -218,6 +218,7 @@ describe("when getting the service config page", () => {
       clientSecret: "new-secret",
       description: "service description",
       grantTypes: ["refresh_token", "authorization_code"],
+      isServiceHidden: false,
       name: "service one",
       postLogoutRedirectUris: "https://new.logout.com",
       postResetUrl: "https://new.postreset.com",

--- a/test/app/services/serviceConfig.test.js
+++ b/test/app/services/serviceConfig.test.js
@@ -3,6 +3,38 @@ const mockUtils = require("../../utils");
 jest.mock("./../../../src/infrastructure/config", () =>
   mockUtils.configMockFactory(),
 );
+jest.mock("./../../../src/infrastructure/logger", () =>
+  mockUtils.loggerMockFactory(),
+);
+jest.mock("login.dfe.validation");
+jest.mock("login.dfe.api-client/encryption", () => ({
+  encrypt: jest.fn((text) => text),
+  decrypt: jest.fn((text) => text),
+}));
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+  updateService: jest.fn(),
+}));
+jest.mock("../../../src/app/services/utils", () => {
+  const actualUtilsFunctions = jest.requireActual(
+    "../../../src/app/services/utils",
+  );
+  return {
+    ...actualUtilsFunctions,
+    processRedirectUris: jest.fn(actualUtilsFunctions.processRedirectUris),
+    determineAuthFlowByRespType: jest.fn(
+      actualUtilsFunctions.determineAuthFlowByRespType,
+    ),
+    getUserServiceRoles: jest.fn(actualUtilsFunctions.getUserServiceRoles),
+    processConfigurationTypes: jest.fn(
+      actualUtilsFunctions.processConfigurationTypes,
+    ),
+    isValidUrl: jest.fn(actualUtilsFunctions.isValidUrl),
+    isCorrectLength: jest.fn(actualUtilsFunctions.isCorrectLength),
+    isCorrectProtocol: jest.fn(actualUtilsFunctions.isCorrectProtocol),
+    checkClientId: jest.fn(),
+  };
+});
 
 const { getGrantTypes } = require("./../../../src/app/services/serviceConfig");
 
@@ -67,5 +99,228 @@ describe("when determining the grant types to set", () => {
       oldService: undefined,
     });
     expect(result).toEqual([]);
+  });
+});
+
+const {
+  SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS,
+} = require("./../../../src/constants/serviceConfigConstants");
+
+describe("SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS", () => {
+  it("contains an isServiceHidden entry", () => {
+    expect(
+      SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS.isServiceHidden,
+    ).toBeDefined();
+  });
+
+  it("isServiceHidden has displayOrder 0 so it renders first on the review page", () => {
+    expect(
+      SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS.isServiceHidden.displayOrder,
+    ).toBe(0);
+  });
+
+  it("isServiceHidden changeLink points to its form group anchor", () => {
+    expect(
+      SERVICE_CONFIG_CHANGES_SUMMARY_DETAILS.isServiceHidden.changeLink,
+    ).toContain("#isServiceHidden-form-group");
+  });
+});
+
+const {
+  isServiceHiddenFromDb,
+} = require("./../../../src/app/services/serviceConfig");
+
+describe("isServiceHiddenFromDb", () => {
+  it("returns true for an id-only service with all four flags set to truthy strings", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: true,
+        isHiddenService: 1,
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for an id-only service when isHiddenService is 0", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: true,
+        isHiddenService: 0,
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for a role-based service when all three params are truthy strings", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: false,
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "true",
+            helpHidden: "true",
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a role-based service when hideSupport is false", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: false,
+        relyingParty: {
+          params: {
+            hideApprover: "true",
+            hideSupport: "false",
+            helpHidden: "true",
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when all params are absent", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: false,
+        relyingParty: { params: {} },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats boolean true as truthy", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: false,
+        relyingParty: {
+          params: { hideApprover: true, hideSupport: true, helpHidden: true },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("treats integer 1 as truthy", () => {
+    expect(
+      isServiceHiddenFromDb({
+        isIdOnlyService: false,
+        relyingParty: {
+          params: { hideApprover: 1, hideSupport: 1, helpHidden: 1 },
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+const { getRequestMock, getResponseMock } = require("../../utils");
+const {
+  getServiceRaw,
+  updateService,
+} = require("login.dfe.api-client/services");
+const {
+  postServiceConfig,
+} = require("../../../src/app/services/serviceConfig");
+const {
+  getUserServiceRoles,
+  checkClientId,
+} = require("../../../src/app/services/utils");
+
+describe("S8 regression — hiding a service with no existing hide params (no crash)", () => {
+  // Reproduces the bug: a service whose relyingParty.params has only
+  // minimumRolesRequired (no hideApprover/hideSupport/helpHidden).
+  // Before the fix, ticking the hide checkbox caused a 500 error on the
+  // review page because editedFields was empty and the session write was
+  // skipped, leaving isServiceHidden undefined when confirmServiceConfig
+  // tried to read it.  The fix added `|| hideServiceChanged` to the
+  // condition so the session always records the hide-state change.
+
+  let req;
+  let res;
+
+  const serviceWithOnlyMinRoles = {
+    id: "service1",
+    name: "service one",
+    description: "service description",
+    isIdOnlyService: false,
+    relyingParty: {
+      client_id: "clientid",
+      client_secret: "dewier-thrombi-confounder-mikado",
+      service_home: "https://www.servicehome.com",
+      postResetUrl: "https://www.postreset.com",
+      redirect_uris: ["https://www.redirect.com"],
+      post_logout_redirect_uris: ["https://www.logout.com"],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      api_secret: "dewier-thrombi-confounder-mikado",
+      token_endpoint_auth_method: undefined,
+      // No hideApprover / hideSupport / helpHidden — only minimumRolesRequired
+      params: { minimumRolesRequired: 5 },
+    },
+  };
+
+  beforeEach(() => {
+    res = getResponseMock();
+
+    // User submits the form with the hide checkbox ticked and otherwise
+    // unchanged values (same redirect URIs, same client ID, etc.)
+    req = getRequestMock({
+      body: {
+        clientId: "clientid",
+        clientSecret: "dewier-thrombi-confounder-mikado",
+        serviceHome: "https://www.servicehome.com",
+        postResetUrl: "https://www.postreset.com",
+        redirect_uris: ["https://www.redirect.com"],
+        post_logout_redirect_uris: ["https://www.logout.com"],
+        response_types: ["code"],
+        apiSecret: "dewier-thrombi-confounder-mikado",
+        tokenEndpointAuthMethod: "client_secret_post",
+        isServiceHidden: "on", // user ticked the hide checkbox
+      },
+      params: { sid: "service1" },
+      query: {},
+      session: {
+        passport: { user: { sub: "user_id_uuid" } },
+      },
+    });
+
+    getUserServiceRoles.mockReset();
+    getUserServiceRoles.mockImplementation(() => Promise.resolve([]));
+    checkClientId.mockReset();
+    checkClientId.mockResolvedValue(null);
+
+    updateService.mockReset();
+    updateService.mockImplementation(() => Promise.resolve([]));
+    getServiceRaw.mockReset();
+    getServiceRaw.mockReturnValueOnce({ ...serviceWithOnlyMinRoles });
+    res.mockResetAll();
+  });
+
+  it("redirects to review page when service has no hide params (only minimumRolesRequired)", async () => {
+    // ARRANGE — all done in beforeEach
+
+    // ACT
+    await postServiceConfig(req, res);
+
+    // ASSERT: should redirect (not crash with a 500) and store the hide change
+    expect(res.redirect).toHaveBeenCalledWith("review-service-configuration#");
+
+    // The session must record the hide-state change so confirmServiceConfig
+    // can display and apply it later (absence of this entry was the S8 root cause)
+    expect(
+      req.session.serviceConfigurationChanges["service1"].isServiceHidden,
+    ).toEqual({ oldValue: "Visible", newValue: "Hidden" });
   });
 });

--- a/test/infrastructure/utils/services.test.js
+++ b/test/infrastructure/utils/services.test.js
@@ -1,0 +1,88 @@
+const path = require("path");
+
+let updateService;
+let updateServiceApiClient;
+let mockRequestRaw;
+
+beforeAll(() => {
+  jest.resetModules();
+
+  updateServiceApiClient = jest.fn().mockResolvedValue();
+  jest.doMock("login.dfe.api-client/services", () => ({
+    updateService: updateServiceApiClient,
+  }));
+
+  mockRequestRaw = jest.fn().mockResolvedValue({ ok: true });
+
+  const apiClientRoot = path.dirname(
+    path.dirname(
+      path.dirname(require.resolve("login.dfe.api-client/services")),
+    ),
+  );
+
+  jest.doMock(path.join(apiClientRoot, "dist", "api", "index.js"), () => ({
+    getApiClient: jest.fn().mockReturnValue({ requestRaw: mockRequestRaw }),
+    ApiName: { Applications: "applications" },
+  }));
+
+  jest.doMock(
+    path.join(apiClientRoot, "dist", "api", "common", "ApiClient.js"),
+    () => ({ RequestMethod: { PATCH: "PATCH" } }),
+  );
+
+  ({ updateService } = require("../../../src/infrastructure/utils/services"));
+});
+
+afterAll(() => {
+  jest.resetModules();
+});
+
+describe("updateService", () => {
+  beforeEach(() => {
+    updateServiceApiClient.mockClear();
+    mockRequestRaw.mockClear();
+  });
+
+  it("passes name to the api-client when provided", async () => {
+    await updateService("svc-123", { name: "My Service" });
+
+    expect(updateServiceApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ name: "My Service" }),
+      }),
+    );
+  });
+
+  it("does NOT include isHiddenService in the api-client update call", async () => {
+    await updateService("svc-123", { isHiddenService: 1 });
+
+    const updateArg = updateServiceApiClient.mock.calls[0][0].update;
+    expect(updateArg).not.toHaveProperty("isHiddenService");
+  });
+
+  it("makes a direct PATCH for isHiddenService=1 when provided", async () => {
+    await updateService("svc-123", { isHiddenService: 1 });
+
+    expect(mockRequestRaw).toHaveBeenCalledWith(
+      "PATCH",
+      "/services/svc-123",
+      expect.objectContaining({ jsonBody: { isHiddenService: 1 } }),
+    );
+  });
+
+  it("makes a direct PATCH for isHiddenService=0 when provided", async () => {
+    await updateService("svc-123", { isHiddenService: 0 });
+
+    expect(mockRequestRaw).toHaveBeenCalledWith(
+      "PATCH",
+      "/services/svc-123",
+      expect.objectContaining({ jsonBody: { isHiddenService: 0 } }),
+    );
+  });
+
+  it("does NOT make a direct PATCH when isHiddenService is not provided", async () => {
+    await updateService("svc-123", { name: "My Service" });
+
+    expect(mockRequestRaw).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## NSA-9688 — Toggle whether or not service is hidden via manage

Adds a "Hide service" checkbox to the service configuration page in manage. When enabled, the service is hidden from the approver, support, and help UIs.

### What changed

**Service configuration page (`confirmServiceConfig.js` / view)**
- Added a "Hide service" checkbox to the service config form
- On save, persists the hidden state depending on service type:
  - **ID-only services** (`isIdOnlyService=true`, e.g. Claim funding): sets `isHiddenService=1` on the service record **and** sets all three hide params (`hideApprover`, `hideSupport`, `helpHidden`) to `1`. All four flags must be true for the service to be hidden — this is the AND gate enforced by the applications API.
  - **Role-based services**: sets the three params (`hideApprover`, `hideSupport`, `helpHidden`) individually via the existing `updateServiceParam` path.

**`infrastructure/utils/services.js`**
- `isHiddenService` is now sent via a direct `requestRaw` PATCH to the applications API.

### Testing

Unit tests cover:
- `isHiddenService` is NOT passed through the api-client update call
- Direct PATCH is called with the correct value when `isHiddenService` is provided
- No direct PATCH is made when `isHiddenService` is not in the update payload

UAT confirmed in dev environment:
- Claim funding (ID-only): hide and unhide both persist correctly
- MYESF (role-based): hide params set and cleared independently
- Service hidden/visible state correctly reflected across approver, support, and help UIs

