### PR TITLE
Render friendly message for sub-service roles request approval

### DIFF
--- a/src/app/services/getAudit.js
+++ b/src/app/services/getAudit.js
@@ -167,6 +167,10 @@ const describeAuditEvent = async (audit, req) => {
     return `Edited permission level to ${editedFields.newValue} for user ${viewedUser.firstName} ${viewedUser.lastName} in organisation ${editedFields.organisation}`;
   }
 
+  if (audit.type === "sub-service" && audit.subType === "sub-service-request") {
+    return "Requested sub-service access";
+  }
+
   return `${audit.type} / ${audit.subType}`;
 };
 

--- a/src/app/services/getAudit.js
+++ b/src/app/services/getAudit.js
@@ -56,6 +56,7 @@ const describeAuditEvent = async (audit, req) => {
   const AUDIT_MESSAGE_SUBTYPES = new Set([
     "service-request-approved",
     "sub-service-request-approved",
+    "sub-service-roles-request-approved",
     "organisation-request-approved",
     "service-request-rejected",
     "sub-service-request-rejected",

--- a/test/app/services/getAudit.test.js
+++ b/test/app/services/getAudit.test.js
@@ -365,6 +365,11 @@ describe("when getting users audit details", () => {
       "email@email.com approved sub-service request for john.doe@email.com",
     ],
     [
+      "sub-service",
+      "sub-service-roles-request-approved",
+      "email@email.com approved sub-service request for john.doe@email.com",
+    ],
+    [
       "manage",
       "organisation-request-approved",
       "email@email.com approved organisation request for john.doe@email.com",


### PR DESCRIPTION
Manage console's getAudit.js had the same gap already fixed in login.dfe.support: sub-service-roles-request-approved was missing from the AUDIT_MESSAGE_SUBTYPES allowlist, so approving a sub-service request via email rendered as raw "sub-service / sub-service-roles-request-approved" text in Manage instead of the friendly audit.message. NSA-9694's AC requires correct rendering in both Support and Manage; this closes the gap in Manage.